### PR TITLE
Fix crash when AniDB mapping contains no text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.3.1 (Unreleased)
 ==================
 
+- Fix crash when AniDB mapping contains no text
 - Use IMDb for finding AniList mappings as well
 - Initial support for other trackers
 - Better handle Discord notifications and log messages when torrent already in client

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -392,6 +392,11 @@ class SeaDexSonarr(SeaDexArr):
                     for ms in anidb_mapping_list:
                         m = ms.findall("mapping")
                         for i in m:
+
+                            # If there's no text, continue
+                            if not i.text:
+                                continue
+
                             # Split at semicolons
                             i_split = i.text.strip(";").split(";")
                             i_split = [x.split("-") for x in i_split]


### PR DESCRIPTION
Closes #24

- Fix crash when AniDB mapping contains no text
