### PR TITLE
ignore_movies_in_radarr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.4.0 (Unreleased)
 ==================
 
+- Added ignore_movies_in_radarr for SeaDexSonarr, which will skip movies flagged as Specials in Sonarr that already
+  exist in Radarr
 - More robust config when parameters added
 - Build Docker for every main update
 - Fix crash when AniDB mapping contains no text

--- a/seadexarr/modules/config_sample.yml
+++ b/seadexarr/modules/config_sample.yml
@@ -1,6 +1,7 @@
 # Parameters for Sonarr
 sonarr_url:
 sonarr_api_key:
+ignore_movies_in_radarr: false  # If True, will not add movies to Sonarr that already exist in Radarr
 
 # Parameters for Radarr
 radarr_url:

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -335,7 +335,7 @@ class SeaDexArr:
         """Get the AniList title from an ID and the SeaDex entry
 
         Args:
-            al_id (str): AniList ID
+            al_id (int): AniList ID
             sd_entry: SeaDex entry
         """
 
@@ -348,6 +348,8 @@ class SeaDexArr:
             anilist_title=anilist_title,
             sd_entry=sd_entry,
         )
+
+        return anilist_title
 
     def get_seadex_dict(
         self,

--- a/seadexarr/modules/seadex_radarr.py
+++ b/seadexarr/modules/seadex_radarr.py
@@ -1,6 +1,7 @@
 import time
 
 import requests
+import arrapi.exceptions
 from arrapi import RadarrAPI
 
 from .discord import discord_push
@@ -239,6 +240,21 @@ class SeaDexRadarr(SeaDexArr):
         radarr_movies.sort(key=lambda x: x.title)
 
         return radarr_movies
+
+    def get_radarr_movie(self, tmdb_id=None, imdb_id=None):
+        """Get Radarr movie for a given TMDB ID or IMDb ID
+
+        Args:
+            tmdb_id (int): TMDB movie ID
+            imdb_id (str): IMDb movie ID
+        """
+
+        try:
+            movie = self.radarr.get_movie(tmdb_id=tmdb_id, imdb_id=imdb_id)
+        except arrapi.exceptions.NotFound:
+            movie = None
+
+        return movie
 
     def get_radarr_release_group(
         self,


### PR DESCRIPTION
Closes #23

- Added ignore_movies_in_radarr for SeaDexSonarr, which will skip movies flagged as Specials in Sonarr that already exist in Radarr
