### PR TITLE
Fix no Discord messages when qbit not specified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.4.2 (Unreleased)
+==================
+
+- Fix Discord messages not getting pushed if no torrent client selected
+- Fix adding too many torrents in one go
+
 0.4.1 (2025-07-31)
 ==================
 

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -612,7 +612,7 @@ class SeaDexArr:
                     n_torrents_added += 1
                     if self.max_torrents_to_add is not None:
                         if self.torrents_added >= self.max_torrents_to_add:
-                            return True
+                            return n_torrents_added
 
                 elif success == "torrent_already_added":
                     self.logger.info(

--- a/seadexarr/modules/seadex_radarr.py
+++ b/seadexarr/modules/seadex_radarr.py
@@ -161,6 +161,11 @@ class SeaDexRadarr(SeaDexArr):
                                 torrent_client="qbit",
                             )
 
+                        # Otherwise, increment by the number of torrents in the SeaDex dict
+                        else:
+                            n_torrents_added += len(seadex_dict)
+                            self.torrents_added += len(seadex_dict)
+
                         # Push a message to Discord if we've added anything
                         if self.discord_url is not None and n_torrents_added > 0:
                             discord_push(

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -259,7 +259,7 @@ class SeaDexSonarr(SeaDexArr):
                     )
 
                     # If we've got stuff, time to do something!
-                    if len(fields) > 0:
+                    if len(seadex_dict) > 0:
 
                         # Keep track of how many torrents we've added
                         n_torrents_added = 0
@@ -270,6 +270,11 @@ class SeaDexSonarr(SeaDexArr):
                                 torrent_dict=seadex_dict,
                                 torrent_client="qbit",
                             )
+
+                        # Otherwise, increment by the number of torrents in the SeaDex dict
+                        else:
+                            n_torrents_added += len(seadex_dict)
+                            self.torrents_added += len(seadex_dict)
 
                         # Push a message to Discord if we've added anything
                         if self.discord_url is not None and n_torrents_added > 0:


### PR DESCRIPTION
Closes #35

- Fix Discord messages not getting pushed if no torrent client selected
- Fix adding too many torrents in one go
