### PR TITLE
Removed trackers that aren't used by SeaDex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.7.0 (Unreleased)
 ==================
 
+- Removed trackers that aren't used by SeaDex
 - Add support for RuTracker
 
 0.6.0 (2025-0813)

--- a/README.md
+++ b/README.md
@@ -125,21 +125,14 @@ description of each is given below.
   releases. Defaults to True
 - `want_best`: Prefer results tagged as best, if any exist. Defaults to True
 - `trackers`: Can manually select a list of trackers. Defaults to None, which will use all the 
-  public trackers and private trackers if `public_only` is False. All possible trackers and whether they are supported 
-  are below.
+  public trackers and private trackers if `public_only` is False. All trackers with torrents on SeaDex, and whether 
+  they are supported are below.
   - Public trackers
     - Nyaa (supported)
     - AnimeTosho (supported)
-    - AniDex
     - RuTracker (supported)
   - Private trackers
     - AB
-    - BeyondHD
-    - PassThePopcorn
-    - BroadcastTheNet
-    - HDBits
-    - Blutopia
-    - Aither
 
 ### Advanced settings
 

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -31,18 +31,18 @@ ALLOWED_ARRS = [
 PUBLIC_TRACKERS = [
     "Nyaa",
     "AnimeTosho",
-    "AniDex",
+    # "AniDex",
     "RuTracker",
 ]
 
 PRIVATE_TRACKERS = [
     "AB",
-    "BeyondHD",
-    "PassThePopcorn",
-    "BroadcastTheNet",
-    "HDBits",
-    "Blutopia",
-    "Aither",
+    # "BeyondHD",
+    # "PassThePopcorn",
+    # "BroadcastTheNet",
+    # "HDBits",
+    # "Blutopia",
+    # "Aither",
 ]
 
 


### PR DESCRIPTION
- Removed trackers that aren't used by SeaDex
