### PR TITLE
Radarr cache check for Sonarr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.8.0 (Unreleased)
 ==================
 
+- If we're ignoring Radarr movies in Sonarr, also check the cache
 - Do a more proper check for episodes in Sonarr
 - Ensure docker-compose run also uses cache
 - Fix crash if AniList ID isn't already in cache

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -224,6 +224,29 @@ class SeaDexSonarr(SeaDexArr):
                     )
                     continue
 
+                # Also check if it's in the Radarr cache, if we have that option
+                if self.ignore_movies_in_radarr:
+                    al_id_in_radarr_cache = self.check_al_id_in_cache(
+                        arr="radarr",
+                        al_id=al_id,
+                        seadex_entry=sd_entry,
+                    )
+                    if al_id_in_radarr_cache:
+                        self.logger.info(
+                            centred_string(
+                                f"Found AniList ID {al_id} in Radarr cache, "
+                                f"and cache time matches SeaDex updated time",
+                                total_length=self.log_line_length,
+                            )
+                        )
+                        self.logger.info(
+                            centred_string(
+                                "-" * self.log_line_length,
+                                total_length=self.log_line_length,
+                            )
+                        )
+                        continue
+
                 # Get the AniList title
                 anilist_title = self.get_anilist_title(
                     al_id=al_id,


### PR DESCRIPTION
- If we're ignoring Radarr movies in Sonarr, also check the cache
