### PR TITLE
Include option to just check torrents by hash

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.9.0 (Unreleased)
 ==================
 
+- Include option to just check torrents by hash
 - Update cache if no suitable releases found
 - Check file sizes, for different versions of releases etc.
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,26 @@ releases tagged on SeaDex. SeaDexArr supports both Sonarr and Radarr.
 
 For Sonarr, it works by scanning through series, matching these up via the TVDB or IMDb IDs to AniList 
 mappings via the Kometa Anime Mappings (https://github.com/Kometa-Team/Anime-IDs), AniDB mappings 
-(https://github.com/Anime-Lists/anime-lists), and ultimately finding releases in the SeaDex database. It then
-attempts to match these releases to specific episodes, to make the comparison as granular and accurate as possible.
-SeaDexArr also checks against filesizes, to attempt to catch when release groups put out updated releases, or those
-at higher quality
-
-For Radarr, this works much the same but instead using the TMDB and IMDb IDs.
+(https://github.com/Anime-Lists/anime-lists), and ultimately finding releases in the SeaDex database. For Radarr, this 
+works much the same but instead using the TMDB and IMDb IDs. 
 
 SeaDexArr will then do some cuts to select a "best" release, which can be pushed to Discord via a bot, and added
 automatically to a torrent client. This should make it significantly more hands-free to keep the best Anime releases 
 out there.
+
+There are then two options for how SeaDexArr will filter releases to grab:
+
+Against existing files (default; `use_torrent_hash_to_filter = False`):
+
+SeaDexArr will attempt to match these releases to release groups in Sonarr/Radarr, and for Sonarr will also try to
+parse filenames to check against individual episodes. SeaDexArr also checks against filesizes, to attempt to catch when 
+release groups put out updated releases, or those at higher quality.
+
+Against torrent hashes (`use_torrent_hash_to_filter = True`):
+
+SeaDexArr will match releases to torrent hashes in the cache. This will ensure that if releases get updated then they
+will be grabbed. However, if you already have an existing library then this could result in torrents being downloaded
+again, and will grab multiple overlapping results if you aren't in interactive mode.
 
 ## Installation
 
@@ -144,6 +154,8 @@ description of each is given below.
 
 ### Advanced settings
 
+- `use_torrent_hash_to_filter`: Can either try and filter by release groups in Sonarr/Radarr (False),
+  or by torrent hashes in the cache (True). Defaults to False. See a more detailed description above
 - `sleep_time`: To avoid hitting API rate limits, after each query SeaDexArr will wait a number 
    of seconds. Defaults to 2
 - `cache_time`: The mappings files don't change all the time, so are cached for a certain number

--- a/seadexarr/modules/config_sample.yml
+++ b/seadexarr/modules/config_sample.yml
@@ -19,6 +19,9 @@ qbit_info:
 sonarr_torrent_category:
 radarr_torrent_category:
 
+# Do you want to filter purely by torrent hash?
+use_torrent_hash_to_filter: false
+
 # Maximum number of torrents to add in one run
 max_torrents_to_add:
 

--- a/seadexarr/modules/seadex_radarr.py
+++ b/seadexarr/modules/seadex_radarr.py
@@ -140,10 +140,11 @@ class SeaDexRadarr(SeaDexArr):
                     sd_entry=sd_entry,
                 )
 
-                # Get info for cache
+                # Setup info for cache
                 cache_details = {
                     "name": anilist_title,
                     "updated_at": sd_entry.updated_at,
+                    "torrent_hashes": [],
                 }
 
                 radarr_release_dict = self.get_radarr_release_dict(
@@ -187,7 +188,8 @@ class SeaDexRadarr(SeaDexArr):
                         sd_entry=sd_entry,
                     )
 
-                seadex_dict = self.filter_seadex_downloads(
+                torrent_hashes, seadex_dict = self.filter_seadex_downloads(
+                    al_id=al_id,
                     seadex_dict=seadex_dict,
                     arr="radarr",
                     arr_release_dict=radarr_release_dict,
@@ -252,6 +254,7 @@ class SeaDexRadarr(SeaDexArr):
                     )
 
                 # Update and save out the cache
+                cache_details.update({"torrent_hashes": torrent_hashes})
                 self.update_cache(
                     arr="radarr",
                     al_id=al_id,

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -263,10 +263,11 @@ class SeaDexSonarr(SeaDexArr):
                     sd_entry=sd_entry,
                 )
 
-                # Get info for cache
+                # Setup info for cache
                 cache_details = {
                     "name": anilist_title,
                     "updated_at": sd_entry.updated_at,
+                    "torrent_hashes": [],
                 }
 
                 # If we have a Radarr instance, and we don't want to add movies that
@@ -387,7 +388,8 @@ class SeaDexSonarr(SeaDexArr):
 
                 # Filter downloads by whether the episodes in each torrent match the release
                 # group we have in Sonarr
-                seadex_dict = self.filter_seadex_downloads(
+                torrent_hashes, seadex_dict = self.filter_seadex_downloads(
+                    al_id=al_id,
                     seadex_dict=seadex_dict,
                     arr="sonarr",
                     arr_release_dict=sonarr_release_dict,
@@ -452,6 +454,7 @@ class SeaDexSonarr(SeaDexArr):
                     )
 
                 # Update and save out the cache
+                cache_details.update({"torrent_hashes": torrent_hashes})
                 self.update_cache(
                     arr="sonarr",
                     al_id=al_id,


### PR DESCRIPTION
- Include option to just check torrents by hash
- Include torrent hash in cache
- Include new 'use_torrent_hash_to_filter' in config
- Update docs
