### PR TITLE
Ignore SeaDex update times

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.9.0 (Unreleased)
 ==================
 
+- Add option to ignore SeaDex update time
+- Don't recreate cache on config change
 - Add a number of useful CLI commands
 - Include option to just check torrents by hash
 - Update cache if no suitable releases found

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ SeaDexArr will match releases to torrent hashes in the cache. This will ensure t
 will be grabbed. However, if you already have an existing library then this could result in torrents being downloaded
 again, and will grab multiple overlapping results if you aren't in interactive mode.
 
+By default, SeaDexArr will not check a particular release again unless SeaDex has updated recently. You can override
+this behaviour by setting ``ignore_seadex_update_times`` to True in the config (see config section below).
+
+> [!TIP]
+> **If you make changes to your config, you should probably remove your cache. You can do so by CLI,
+> use ``seadexarr cache remove`` (see below for more details).**
+
 ## Installation
 
 SeaDexArr is available as a Docker container. Into a docker-compose file:
@@ -177,6 +184,8 @@ description of each is given below.
 
 ### Advanced settings
 
+- `ignore_seadex_update_times`: If True, will not check against the update times in the cache to
+  decide whether to search for a release. Defaults to False
 - `use_torrent_hash_to_filter`: Can either try and filter by release groups in Sonarr/Radarr (False),
   or by torrent hashes in the cache (True). Defaults to False. See a more detailed description above
 - `sleep_time`: To avoid hitting API rate limits, after each query SeaDexArr will wait a number 

--- a/seadexarr/modules/config_sample.yml
+++ b/seadexarr/modules/config_sample.yml
@@ -19,6 +19,9 @@ qbit_info:
 sonarr_torrent_category:
 radarr_torrent_category:
 
+# Ignore SeaDex update times?
+ignore_seadex_update_times: false
+
 # Do you want to filter purely by torrent hash?
 use_torrent_hash_to_filter: false
 

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -204,8 +204,12 @@ class SeaDexArr:
 
             self.qbit = qbit
 
+        self.ignore_seadex_update_times = self.config.get(
+            "ignore_seadex_update_times", False
+        )
+
         self.use_torrent_hash_to_filter = self.config.get(
-            f"use_torrent_hash_to_filter", False
+            "use_torrent_hash_to_filter", False
         )
 
         # Hooks between torrents and Arrs, and torrent number bookkeeping
@@ -270,11 +274,11 @@ class SeaDexArr:
             cache = self.setup_cache()
         self.cache = cache
 
-        # Check the package or config hasn't updated, else reset
-        # the cache
-        cache_updated = self.check_cache_updates()
-        if cache_updated:
-            self.cache = self.setup_cache()
+        # # Check the package or config hasn't updated, else reset
+        # # the cache
+        # cache_updated = self.check_cache_updates()
+        # if cache_updated:
+        #     self.cache = self.setup_cache()
 
         self.log_line_sep = "="
         self.log_line_length = 80

--- a/seadexarr/modules/seadex_radarr.py
+++ b/seadexarr/modules/seadex_radarr.py
@@ -119,7 +119,7 @@ class SeaDexRadarr(SeaDexArr):
                     seadex_entry=sd_entry,
                 )
 
-                if al_id_in_cache:
+                if al_id_in_cache and not self.ignore_seadex_update_times:
                     self.logger.info(
                         centred_string(
                             f"Cache time for AniList ID {al_id} matches SeaDex updated time",

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -219,7 +219,7 @@ class SeaDexSonarr(SeaDexArr):
                     seadex_entry=sd_entry,
                 )
 
-                if al_id_in_cache:
+                if al_id_in_cache and not self.ignore_seadex_update_times:
                     self.logger.info(
                         centred_string(
                             f"Cache time for AniList ID {al_id} matches SeaDex updated time",
@@ -235,7 +235,7 @@ class SeaDexSonarr(SeaDexArr):
                     continue
 
                 # Also check if it's in the Radarr cache, if we have that option
-                if self.ignore_movies_in_radarr:
+                if self.ignore_movies_in_radarr and not self.ignore_seadex_update_times:
                     al_id_in_radarr_cache = self.check_al_id_in_cache(
                         arr="radarr",
                         al_id=al_id,


### PR DESCRIPTION
- Add option to ignore SeaDex update time
- Don't recreate cache on config change
- Update docs
