### PR TITLE
pynyaa: bump to 3.0.0 and update usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "colorlog == 6.9.0",
     "discordwebhook == 1.0.3",
     "httpx == 0.28.1",
-    "pynyaa == 2.0.0",
+    "pynyaa == 3.0.0",
     "PyYAML == 6.0.2",
     "qbittorrent-api == 2025.7.0",
     "requests == 2.32.5",

--- a/seadexarr/modules/torrent.py
+++ b/seadexarr/modules/torrent.py
@@ -15,7 +15,9 @@ def get_nyaa_url(url):
         url (str): URL to get Nyaa torrent link
     """
 
-    return pynyaa.get(url).torrent.url
+    parsed_url = pynyaa.get(url).torrent.url
+
+    return parsed_url
 
 
 def get_animetosho_url(url):

--- a/seadexarr/modules/torrent.py
+++ b/seadexarr/modules/torrent.py
@@ -15,10 +15,7 @@ def get_nyaa_url(url):
         url (str): URL to get Nyaa torrent link
     """
 
-    nyaa = pynyaa.get(url)
-    parsed_url = str(nyaa.torrent_file)
-
-    return parsed_url
+    return pynyaa.get(url).torrent.url
 
 
 def get_animetosho_url(url):


### PR DESCRIPTION
[`pynyaa` v3.0.0 introduces breaking API changes.](https://github.com/Ravencentric/pynyaa/releases/tag/v3.0.0)
This updates the dependency and modifies torrent.py to match the new API.
