### PR TITLE
Add "torrent_tags"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.0.0 (Unreleased)
 ==================
 
+- Add "torrent_tags", which allows you to tag torrents as added to qBittorrent
 - Add "ignore tags" option, which allows you to filter out various tags
 - Use AniBridge mappings to mop up missed Sonarr/Radarr titles
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ description of each is given below.
    set a category
 - `radarr_torrent_category`: Radarr torrent import category, if you have one. Defaults to None, which won't 
    set a category
+- `torrent_tags`: Tags to add to the torrent when added to a client. Defaults to None, which won't add any tags
 - `max_torrents_to_add`: used to limit the number of torrents you add in one run. Defaults to None, which 
    will just add everything it finds
 

--- a/seadexarr/modules/config_sample.yml
+++ b/seadexarr/modules/config_sample.yml
@@ -18,6 +18,7 @@ qbit_info:
 # Categories for added torrents
 sonarr_torrent_category:
 radarr_torrent_category:
+torrent_tags:
 
 # Ignore SeaDex update times?
 ignore_seadex_update_times: false

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -214,6 +214,7 @@ class SeaDexArr:
 
         # Hooks between torrents and Arrs, and torrent number bookkeeping
         self.torrent_category = self.config.get(f"{arr}_torrent_category", None)
+        self.torrent_tags = self.config.get("torrent_tags", None)
         self.max_torrents_to_add = self.config.get("max_torrents_to_add", None)
         self.torrents_added = 0
 
@@ -1429,6 +1430,7 @@ class SeaDexArr:
         result = self.qbit.torrents_add(
             urls=torrent_url,
             category=self.torrent_category,
+            tags=self.torrent_tags,
         )
         if result != "Ok.":
             raise Exception("Failed to add torrent")


### PR DESCRIPTION
Fixes #91

- Add "torrent_tags", which allows you to tag torrents as added to qBittorrent
- Update README.md
