### PR TITLE
Ignore empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.0.0 (Unreleased)
 ==================
 
+- Add "ignore_empty" option, which allows you to ignore series/movies that don't already have something downloaded
 - Add "torrent_tags", which allows you to tag torrents as added to qBittorrent
 - Add "ignore tags" option, which allows you to filter out various tags
 - Use AniBridge mappings to mop up missed Sonarr/Radarr titles

--- a/seadexarr/modules/config_sample.yml
+++ b/seadexarr/modules/config_sample.yml
@@ -3,11 +3,13 @@ sonarr_url:
 sonarr_api_key:
 sonarr_ignore_unmonitored: false  # If True, will not grab releases that are unmonitored in Sonarr
 ignore_movies_in_radarr: false  # If True, will not add movies to Sonarr that already exist in Radarr
+sonarr_ignore_empty: false  # If True, will ignore Series that have nothing already on disk
 
 # Parameters for Radarr
 radarr_url:
 radarr_api_key:
 radarr_ignore_unmonitored: false  # If True, will not grab releases that are unmonitored in Radarr
+radarr_ignore_empty: false  # If True, will ignore Movies that have nothing already on disk
 
 # qBittorrent parameters
 qbit_info:

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -185,6 +185,9 @@ class SeaDexArr:
         # Ignore unmonitored flag
         self.ignore_unmonitored = self.config.get(f"{arr}_ignore_unmonitored", False)
 
+        # Ignore empty flag
+        self.ignore_empty = self.config.get(f"{arr}_ignore_empty", False)
+
         # qBit
         self.qbit = None
         qbit_info = self.config.get("qbit_info", None)

--- a/seadexarr/modules/seadex_radarr.py
+++ b/seadexarr/modules/seadex_radarr.py
@@ -326,6 +326,10 @@ class SeaDexRadarr(SeaDexArr):
 
         for m in self.radarr.all_movies():
 
+            # If we have nothing and we're ignoring empty movies, skip
+            if m.sizeOnDisk == 0 and self.ignore_empty:
+                continue
+
             # Check by TMDB IDs
             tmdb_id = m.tmdbId
             if tmdb_id in all_tmdb_ids and m not in radarr_movies:

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -618,6 +618,10 @@ class SeaDexSonarr(SeaDexArr):
 
         for s in self.sonarr.all_series():
 
+            # If we have nothing and we're ignoring empty series, skip
+            if s.sizeOnDisk == 0 and self.ignore_empty:
+                continue
+
             # Check by TVDB IDs
             tvdb_id = s.tvdbId
             if tvdb_id in all_tvdb_ids and s not in sonarr_series:


### PR DESCRIPTION
Fixes #112

- Add "ignore_empty" option, which allows you to ignore series/movies that don't already have something downloaded
