### PR TITLE
Ability to disable mapping sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,11 @@ description of each is given below.
 - `interactive`: If True, will enable interactive mode, which when multiple torrent options are
    found, will ask for input to choose one. Otherwise, will just grab everything. Defaults to False
 - `anime_mappings`: Can provide custom Anime ID mappings here. Otherwise, will use the Kometa mappings.
-  The general user should not set this. Defaults to None
+  Set to False to disable Anime ID mappings entirely. The general user should not set this. Defaults to None
 - `anidb_mappings`: Can provide custom AniDB mappings here. Otherwise, will use the AniDB mappings.
-  The general user should not set this. Defaults to None
+  Set to False to disable AniDB mappings entirely. The general user should not set this. Defaults to None
 - `anibridge_mappings`: Can provide custom AniBridge mappings here. Otherwise, will use the PlexAniBridge mappings.
-  The general user should not set this. Defaults to None
+  Set to False to disable AniBridge mappings entirely. The general user should not set this. Defaults to None
 - `log_level`: Controls the level of logging. Can be WARNING, INFO, or DEBUG. Defaults to "INFO"
 
 ## Roadmap

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -247,16 +247,31 @@ class SeaDexArr:
         self.cache_time = self.config.get("cache_time", 1)
 
         # Get the mapping files
-        anime_mappings = self.config.get("anime_mappings", None)
-        anidb_mappings = self.config.get("anidb_mappings", None)
-        anibridge_mappings = self.config.get("anibridge_mappings", None)
+        anime_mappings_cfg = self.config.get("anime_mappings", None)
+        anidb_mappings_cfg = self.config.get("anidb_mappings", None)
+        anibridge_mappings_cfg = self.config.get("anibridge_mappings", None)
 
-        if anime_mappings is None:
+        if anime_mappings_cfg is False:
+            anime_mappings = {}
+        elif anime_mappings_cfg is None:
             anime_mappings = self.get_anime_mappings()
-        if anidb_mappings is None:
+        else:
+            anime_mappings = anime_mappings_cfg
+
+        if anidb_mappings_cfg is False:
+            anidb_mappings = None
+        elif anidb_mappings_cfg is None:
             anidb_mappings = self.get_anidb_mappings()
-        if anibridge_mappings is None:
+        else:
+            anidb_mappings = anidb_mappings_cfg
+
+        if anibridge_mappings_cfg is False:
+            anibridge_mappings = {}
+        elif anibridge_mappings_cfg is None:
             anibridge_mappings = self.get_anibridge_mappings()
+        else:
+            anibridge_mappings = anibridge_mappings_cfg
+
         self.anime_mappings = anime_mappings
         self.anidb_mappings = anidb_mappings
         self.anibridge_mappings = anibridge_mappings
@@ -517,22 +532,24 @@ class SeaDexArr:
 
         # Start by looking through our base case, which are the Kometa
         # Anime IDs. Save these to a dict where the key is the AniList ID
-        anilist_mappings = self.get_mappings_from_anime_mappings(
-            tvdb_id=tvdb_id,
-            tmdb_id=tmdb_id,
-            imdb_id=imdb_id,
-            tmdb_type=tmdb_type,
-            anilist_mappings=anilist_mappings,
-        )
+        if self.anime_mappings:
+            anilist_mappings = self.get_mappings_from_anime_mappings(
+                tvdb_id=tvdb_id,
+                tmdb_id=tmdb_id,
+                imdb_id=imdb_id,
+                tmdb_type=tmdb_type,
+                anilist_mappings=anilist_mappings,
+            )
 
         # Then, look through the AniBridge mappings
-        anilist_mappings = self.get_mappings_from_anibridge_mappings(
-            tvdb_id=tvdb_id,
-            tmdb_id=tmdb_id,
-            imdb_id=imdb_id,
-            tmdb_type=tmdb_type,
-            anilist_mappings=anilist_mappings,
-        )
+        if self.anibridge_mappings:
+            anilist_mappings = self.get_mappings_from_anibridge_mappings(
+                tvdb_id=tvdb_id,
+                tmdb_id=tmdb_id,
+                imdb_id=imdb_id,
+                tmdb_type=tmdb_type,
+                anilist_mappings=anilist_mappings,
+            )
 
         # Sort by AniList ID
         anilist_mappings = dict(sorted(anilist_mappings.items()))

--- a/seadexarr/modules/seadex_radarr.py
+++ b/seadexarr/modules/seadex_radarr.py
@@ -312,6 +312,9 @@ class SeaDexRadarr(SeaDexArr):
             self.anime_mappings,
             self.anibridge_mappings,
         ]:
+            if not mapping:
+                continue
+
             all_tmdb_ids.extend(
                 mapping[x].get("tmdb_movie_id", None)
                 for x in mapping

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -604,6 +604,9 @@ class SeaDexSonarr(SeaDexArr):
             self.anime_mappings,
             self.anibridge_mappings,
         ]:
+            if not mapping:
+                continue
+
             all_tvdb_ids.extend(
                 mapping[x].get("tvdb_id", None)
                 for x in mapping
@@ -733,8 +736,14 @@ class SeaDexSonarr(SeaDexArr):
         # be for anything not marked as TV, and specials as marked by
         # being in Season 0
         anidb_mapping_dict = {}
-        if al_format not in ["TV"] or tvdb_season == 0 and anidb_id is not None:
-            anidb_item = self.anidb_mappings.findall(f"anime[@anidbid='{anidb_id}']")
+        if (
+            self.anidb_mappings is not None
+            and anidb_id is not None
+            and (al_format not in ["TV"] or tvdb_season == 0)
+        ):
+            anidb_item = self.anidb_mappings.findall(
+                f"anime[@anidbid='{anidb_id}']"
+            )
 
             # If we don't find anything, no worries. If we find multiple, worries
             if len(anidb_item) > 1:


### PR DESCRIPTION
This PR introduces the ability to disable any of the three mapping sources by setting them to `False` in the config.

I'm a maintainer of the AniBridge mappings repo, so I'm familiar with all three of the mapping providers seadexarr supports. Anime-Lists (`anidb_mappings`) is essentially a subset of Kometa mappings (`anime_mappings`), which itself is a subset of AniBridge mappings, so it's a little redundant from my perspective to be using all three - AniBridge already captures all of them.

Additionally, given that SeaDex is AniList-first, and both Anime-Lists and Kometa are AniDB-first, AniBridge (which is also AniList-first) seems to be the natural choice.

Of course, this PR doesn't modify any pre-existing default behaviors; it is up to the user to explicitly disable any mapping source through the config.