### PR TITLE
feat: make nyaa host configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ description of each is given below.
 - `anibridge_v3_mappings`: Can provide custom AniBridge mappings here. Otherwise, will use the PlexAniBridge mappings.
   Set to False to disable AniBridge mappings entirely. The general user should not set this. Defaults to None
 - `log_level`: Controls the level of logging. Can be WARNING, INFO, or DEBUG. Defaults to "INFO"
+- `nyaa_host`: Configures an alternative hostname to use when connecting to nyaa. Defaults to "nyaa.si"
 
 ## Roadmap
 

--- a/seadexarr/modules/config_sample.yml
+++ b/seadexarr/modules/config_sample.yml
@@ -45,3 +45,4 @@ cache_time: 1
 interactive: false
 anibridge_v3_mappings:
 log_level: "INFO"
+nyaa_host: "nyaa.si" # Choose between nyaa.si proxies

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -265,6 +265,9 @@ class SeaDexArr:
         else:
             self.logger = logger
 
+        # Set nyaa.si host
+        self.nyaa_host = self.config.get("nyaa_host", "nyaa.si")
+
         # Instantiate the SeaDex API
         self.seadex = SeaDexEntry()
 
@@ -1291,7 +1294,7 @@ class SeaDexArr:
 
                 # Nyaa
                 if tracker.lower() == "nyaa":
-                    parsed_url = get_nyaa_url(url=url)
+                    parsed_url = get_nyaa_url(url=url, host=self.nyaa_host)
 
                 # AnimeTosho
                 elif tracker.lower() == "animetosho":

--- a/seadexarr/modules/torrent.py
+++ b/seadexarr/modules/torrent.py
@@ -1,6 +1,6 @@
 from urllib.parse import urljoin, urlencode
 
-import pynyaa
+from pynyaa import Nyaa
 import requests
 from bs4 import BeautifulSoup
 
@@ -8,14 +8,16 @@ ANIMETOSHO_FEED_URL = "https://animetosho.org/feed/json"
 RUTRACKER_MAGNET_ANNOUNCE = "http://bt2.t-ru.org/ann?magnet"
 
 
-def get_nyaa_url(url):
+def get_nyaa_url(url, host):
     """Get Nyaa torrent link from URL
 
     Args:
         url (str): URL to get Nyaa torrent link
+        host (str): Hostname used for Nyaa
     """
 
-    parsed_url = pynyaa.get(url).torrent.url
+    with Nyaa(base_url = f"https://{host}/") as nyaa:
+        parsed_url = nyaa.get(url).torrent.url
 
     return parsed_url
 


### PR DESCRIPTION
Adds a new configuration field called `nyaa_host`, allowing a user to change which host is used to contact Nyaa. The main Nyaa domain has a tendency to get overloaded and/or rate-limit you easily, so a bunch of alternatives are available.

Prowlarr has a similar feature in place, with their own [maintained list of Nyaa proxies](https://github.com/Prowlarr/Indexers/blob/df68bbc660101b3cbde8acc4560b88cd32154d5b/definitions/v11/nyaasi.yml#L10-L14). 