### PR TITLE
fix: handle null episodeFile in filter_by_release_group

### DIFF
--- a/seadexarr/modules/anilist.py
+++ b/seadexarr/modules/anilist.py
@@ -41,6 +41,16 @@ def get_query(al_id):
     return j
 
 
+def _media(j: dict) -> dict:
+    """Safely extract the Media object from an AniList response.
+
+    AniList returns {"data": null} for removed/incomplete entries.
+    dict.get(key, {}) only uses the default when the key is absent,
+    not when it exists with a null value — so we use `or {}` guards.
+    """
+    return ((j.get("data") or {}).get("Media") or {})
+
+
 def get_anilist_n_eps(
     al_id,
     al_cache=None,
@@ -64,7 +74,7 @@ def get_anilist_n_eps(
         al_cache[al_id] = copy.deepcopy(j)
 
     # Pull out number of episodes
-    n_eps = j.get("data", {}).get("Media", {}).get("episodes", None)
+    n_eps = _media(j).get("episodes", None)
 
     return n_eps, al_cache
 
@@ -92,9 +102,8 @@ def get_anilist_title(
         al_cache[al_id] = copy.deepcopy(j)
 
     # Prefer the english title, but fall back to romaji
-    title = j.get("data", {}).get("Media", {}).get("title", {}).get("english", None)
-    if title is None:
-        title = j.get("data", {}).get("Media", {}).get("title", {}).get("romaji", None)
+    title_obj = (_media(j).get("title") or {})
+    title = title_obj.get("english") or title_obj.get("romaji")
 
     return title, al_cache
 
@@ -121,7 +130,7 @@ def get_anilist_thumb(
         j = get_query(al_id)
         al_cache[al_id] = copy.deepcopy(j)
 
-    thumb = j.get("data", {}).get("Media", {}).get("coverImage", {}).get("large", None)
+    thumb = (_media(j).get("coverImage") or {}).get("large", None)
 
     return thumb, al_cache
 
@@ -148,6 +157,6 @@ def get_anilist_format(
         j = get_query(al_id)
         al_cache[al_id] = copy.deepcopy(j)
 
-    al_format = j.get("data", {}).get("Media", {}).get("format", None)
+    al_format = _media(j).get("format", None)
 
     return al_format, al_cache

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -1186,7 +1186,7 @@ class SeaDexArr:
                             # Get Season, Episode, and size numbers for Sonarr and SeaDex
                             sonarr_ep_season = sonarr_ep.get("seasonNumber", 999)
                             sonarr_ep_episode = sonarr_ep.get("episodeNumber", 999)
-                            sonarr_ep_size = sonarr_ep.get("episodeFile", {}).get(
+                            sonarr_ep_size = (sonarr_ep.get("episodeFile") or {}).get(
                                 "size", None
                             )
 
@@ -1208,7 +1208,7 @@ class SeaDexArr:
                                 )
 
                                 # Check SeaDex release group matches the episode release group in Sonarr
-                                sonarr_rg = sonarr_ep.get("episodeFile", {}).get(
+                                sonarr_rg = (sonarr_ep.get("episodeFile") or {}).get(
                                     "releaseGroup", None
                                 )
 

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -856,13 +856,13 @@ class SeaDexSonarr(SeaDexArr):
                 missing_eps += 1
                 continue
 
-            release_group = ep.get("episodeFile", {}).get("releaseGroup", None)
+            release_group = (ep.get("episodeFile") or {}).get("releaseGroup", None)
             if release_group is None or release_group == "":
                 continue
 
             if release_group not in sonarr_release_dict:
                 sonarr_release_dict[release_group] = {"size": []}
-            size = ep.get("episodeFile", {}).get("size", None)
+            size = (ep.get("episodeFile") or {}).get("size", None)
             sonarr_release_dict[release_group]["size"].append(size)
 
         if missing_eps > 0:


### PR DESCRIPTION
sonarr_ep.get('episodeFile', {}) returns None when the key exists with a null value (episode with no downloaded file). dict.get() only uses the default when the key is absent, not when it is present but None. Calling .get('size') or .get('releaseGroup') on that None raised AttributeError: 'NoneType' object has no attribute 'get'.

Fix both occurrences with (... or {}) so a null episodeFile is treated identically to a missing one.