### PR TITLE
fix: handle +-grouped AniDB mappings and quiet alt-acceptable tagging logs

### DIFF
--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Build and push Docker image to GHCR
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     permissions:
@@ -21,15 +21,22 @@ jobs:
       contents: read
       attestations: write
       id-token: write
+
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
@@ -37,6 +44,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         id: push
@@ -45,12 +57,15 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/AUDIT_MODE.md
+++ b/AUDIT_MODE.md
@@ -1,0 +1,201 @@
+# SeaDexArr — Audit Mode
+
+Audit mode scans your Sonarr library against SeaDex, applies Sonarr tags, and
+sends Discord notifications. **It never downloads, grabs, or replaces files.**
+
+---
+
+## Quick start
+
+```bash
+# Preview what would change (no Sonarr mutations, no Discord)
+seadexarr audit --dry-run
+
+# Apply Sonarr tags (still no downloads)
+seadexarr audit --apply-tags
+
+# Send Discord notifications only (no tag changes)
+seadexarr audit --notify-only
+```
+
+All three flags can be combined; `--dry-run` always wins over `--apply-tags`.
+
+---
+
+## What it does
+
+For each Sonarr series that has an AniList mapping:
+
+1. Looks up the series in SeaDex.
+2. Classifies coverage:
+   - **`none`** — no SeaDex entry.
+   - **`partial`** — SeaDex entry exists but no releases pass your filters
+     (`public_only`, `want_best`, `trackers`, `ignore_tags`).
+   - **`full`** — at least one release passes filters.
+3. Checks whether the SeaDex-recommended release differs from your current
+   library files (release-group or torrent-hash comparison — same logic as
+   the existing grab mode).
+4. Flags `upgrade_available` when there is a mismatch.
+5. Flags `too_large` when the recommended release exceeds your size limits.
+6. Applies Sonarr tags (when `--apply-tags` or `update_sonarr_tags: true`).
+7. Sends Discord notifications for new or changed findings (deduped by
+   persistent state so you are not spammed on every run).
+
+---
+
+## Config
+
+Add an `audit:` section to your `config.yml`. Running `seadexarr config init`
+copies a template with all defaults already filled in.
+
+```yaml
+audit:
+  enabled: false
+  dry_run: true           # safe default: no mutations until you set false
+  sonarr_only: true
+  notify_discord: true
+  update_sonarr_tags: true
+  remove_stale_tags: false  # only removes tags listed in audit.tags
+
+  tags:
+    full_seadex: seadex
+    partial_seadex: partial-seadex
+    upgrade_available: seadex-upgrade-available
+    too_large: seadex-too-large
+    ignored: seadex-ignored
+
+  size_filters:
+    enabled: true
+    max_absolute_gb: 80          # flag if SeaDex release > 80 GB total
+    max_size_multiplier: 2.0     # flag if > 2× your current files' size
+    notify_when_too_large: true
+    tag_when_too_large: true
+
+  discord:
+    notify_on_new_seadex_match: true
+    notify_on_new_upgrade_available: true
+    notify_on_partial_match: true
+    notify_on_too_large: true
+    notify_on_no_change: false
+    batch_notifications: true    # group up to 10 series per Discord message
+
+  state:
+    enabled: true
+    path:    # leave blank to use /config/audit_state.json
+```
+
+The `discord_url` from the top-level config is reused.
+
+---
+
+## Sonarr tags
+
+Tags are created automatically if they do not exist. Only tags listed in
+`audit.tags` are ever removed (only when `remove_stale_tags: true`). Tags
+you add manually are never touched.
+
+| Tag | Applied when |
+|-----|-------------|
+| `seadex` | Full SeaDex coverage |
+| `partial-seadex` | Entry exists but nothing passes your filters |
+| `seadex-upgrade-available` | Recommended release differs from library |
+| `seadex-too-large` | Upgrade available but exceeds size limits |
+| `seadex-ignored` | Reserved for manual use; never applied automatically |
+
+---
+
+## State file
+
+`audit_state.json` (default `/config/audit_state.json`) tracks per-series
+state between runs so Discord is not spammed. Notifications fire only when:
+
+- A series newly appears on SeaDex.
+- Coverage changes (`none → partial`, `partial → full`, etc.).
+- The recommended release group changes.
+- Your library files change and now differ from the recommendation.
+- A release newly crosses the "too large" threshold.
+
+Delete the state file to reset and re-notify everything.
+
+---
+
+## Persistent state fields
+
+```json
+{
+  "sonarr_id": 12345,
+  "tvdb_id": 67890,
+  "title": "My Favourite Show",
+  "seadex_status": "full",
+  "seadex_rgs": ["SubsPlease"],
+  "seadex_size_bytes": 5368709120,
+  "library_rgs": ["EMBER"],
+  "upgrade_available": true,
+  "too_large": false,
+  "last_notified": "2026-01-01T12:00:00+00:00",
+  "last_audited": "2026-01-01T12:00:00+00:00"
+}
+```
+
+---
+
+## Docker / Unraid
+
+Mount `/config` persistently. The state file, config, and cache all live there.
+
+```yaml
+# docker-compose.yml excerpt
+volumes:
+  - /mnt/user/appdata/seadexarr:/config
+environment:
+  - CONFIG_DIR=/config
+```
+
+Run audit on demand:
+
+```bash
+docker exec seadexarr seadexarr audit --dry-run
+docker exec seadexarr seadexarr audit --apply-tags
+```
+
+Or add a scheduled cron inside the container / via Unraid's scheduler.
+
+---
+
+## Running tests
+
+```bash
+pip install pytest
+python -m pytest tests/test_audit.py -v
+```
+
+---
+
+## Logged summary
+
+After each run, the log shows:
+
+```
+================================================================================
+Audit Summary
+================================================================================
+Scanned: 150
+Matched to SeaDex: 87
+Full coverage: 72
+Partial coverage: 15
+Upgrade available: 23
+Too large: 4
+Tags updated: 23
+Notifications sent: 6
+Errors: 0
+================================================================================
+```
+
+---
+
+## Guarantee
+
+Audit mode **never calls** `add_torrent()` or `add_torrent_to_qbit()`.
+These methods exist on the parent class but are not invoked anywhere in
+`SeaDexAudit.run()`. The qBittorrent client may be initialized (if your
+existing config has credentials) but is never used in audit mode.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@
 - Add "torrent_tags", which allows you to tag torrents as added to qBittorrent
 - Add "ignore tags" option, which allows you to filter out various tags
 - Use AniBridge mappings to mop up missed Sonarr/Radarr titles
+- Fix specials/OVAs/movies mis-mapping to the wrong episode: the AniDB ID from
+  the Kometa Anime-IDs key is now folded into the mapping, so the AniDB episode
+  mapping-list is actually consulted (previously dead code) instead of a naive
+  offset slice. Stops false "missing"/upgrade flags for entries like Attack on
+  Titan ~Chronicle~
+- Disambiguate duplicate AniDB mappings by TVDB ID and fail soft instead of
+  erroring out the whole series
 
 0.9.0 (2025-09-13)
 ==================

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,36 @@
-FROM python:latest
+FROM python:3.13-slim
+
 WORKDIR /app
 COPY . /app
-RUN pip install setuptools
-RUN pip install -e .
 
+RUN pip install --no-cache-dir setuptools && \
+    pip install --no-cache-dir -e .
+
+# --- Core paths ---
 ENV CONFIG_DIR=/config
 ENV DOCKER_ENV=true
 
-ENTRYPOINT ["seadexarr"]
+# --- Run mode ---
+# audit       run audit on a repeating schedule (default)
+# audit-once  run audit once and exit
+# sync        run existing grab/sync mode on a repeating schedule
+ENV RUN_MODE=audit
+
+# --- Schedule (hours) ---
+ENV SCHEDULE_TIME=6
+ENV AUDIT_SCHEDULE_TIME=6
+
+# --- Audit flags passed to "seadexarr audit" ---
+# Options: --apply-tags  --dry-run  --notify-only
+# Combine:  --apply-tags   (apply tags, still no downloads)
+ENV AUDIT_ARGS=--apply-tags
+
+# --- Logging ---
+ENV LOG_LEVEL=INFO
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+VOLUME ["/config"]
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,19 +14,32 @@ set -e
 AUDIT_SCHEDULE_TIME="${AUDIT_SCHEDULE_TIME:-6}"
 AUDIT_ARGS="${AUDIT_ARGS:---apply-tags}"
 
-# Clean exit on SIGTERM / SIGINT (handles the sleep period between runs)
-trap 'exit 0' TERM INT
-
 case "${RUN_MODE:-audit}" in
 
   audit)
     echo "SeaDexArr: audit mode, every ${AUDIT_SCHEDULE_TIME}h (args: ${AUDIT_ARGS})"
+    _child_pid=""
+    # Forward SIGTERM/SIGINT to the child process (Python or sleep) so that
+    # Python's graceful-shutdown handler fires during an audit run, and the
+    # inter-run sleep is interrupted immediately on stop.
+    _forward_term() {
+      if [ -n "$_child_pid" ]; then
+        kill -TERM "$_child_pid" 2>/dev/null
+        wait "$_child_pid" 2>/dev/null || true
+      fi
+      exit 0
+    }
+    trap '_forward_term' TERM INT
     while true; do
-      seadexarr audit ${AUDIT_ARGS}
+      seadexarr audit ${AUDIT_ARGS} &
+      _child_pid=$!
+      wait $_child_pid || true
+      _child_pid=""
       echo "Audit complete. Next run in ${AUDIT_SCHEDULE_TIME}h."
-      # Run sleep in background and wait so the trap fires immediately
       sleep $(( AUDIT_SCHEDULE_TIME * 3600 )) &
-      wait $!
+      _child_pid=$!
+      wait $_child_pid || true
+      _child_pid=""
     done
     ;;
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# SeaDexArr Docker entrypoint.
+# Controlled by RUN_MODE env var:
+#   audit       (default) — run audit on a repeating schedule
+#   audit-once  — run audit once and exit
+#   sync        — run existing grab/sync mode on a repeating schedule
+
+set -e
+
+AUDIT_SCHEDULE_TIME="${AUDIT_SCHEDULE_TIME:-6}"
+AUDIT_ARGS="${AUDIT_ARGS:---apply-tags}"
+
+case "${RUN_MODE:-audit}" in
+
+  audit)
+    echo "SeaDexArr: audit mode, every ${AUDIT_SCHEDULE_TIME}h (args: ${AUDIT_ARGS})"
+    while true; do
+      seadexarr audit ${AUDIT_ARGS}
+      echo "Audit complete. Next run in ${AUDIT_SCHEDULE_TIME}h."
+      sleep $(( AUDIT_SCHEDULE_TIME * 3600 ))
+    done
+    ;;
+
+  audit-once)
+    echo "SeaDexArr: audit-once mode (args: ${AUDIT_ARGS})"
+    exec seadexarr audit ${AUDIT_ARGS}
+    ;;
+
+  sync)
+    echo "SeaDexArr: sync mode, every ${SCHEDULE_TIME:-6}h"
+    exec seadexarr "$@"
+    ;;
+
+  *)
+    echo "SeaDexArr: unknown RUN_MODE='${RUN_MODE}', falling back to audit"
+    exec seadexarr audit ${AUDIT_ARGS}
+    ;;
+
+esac

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,11 +4,18 @@
 #   audit       (default) — run audit on a repeating schedule
 #   audit-once  — run audit once and exit
 #   sync        — run existing grab/sync mode on a repeating schedule
+#
+# SIGTERM/SIGINT during an audit run is forwarded to the Python process,
+# which finishes the current series then saves state and exits cleanly.
+# SIGTERM during the inter-run sleep causes an immediate clean exit.
 
 set -e
 
 AUDIT_SCHEDULE_TIME="${AUDIT_SCHEDULE_TIME:-6}"
 AUDIT_ARGS="${AUDIT_ARGS:---apply-tags}"
+
+# Clean exit on SIGTERM / SIGINT (handles the sleep period between runs)
+trap 'exit 0' TERM INT
 
 case "${RUN_MODE:-audit}" in
 
@@ -17,7 +24,9 @@ case "${RUN_MODE:-audit}" in
     while true; do
       seadexarr audit ${AUDIT_ARGS}
       echo "Audit complete. Next run in ${AUDIT_SCHEDULE_TIME}h."
-      sleep $(( AUDIT_SCHEDULE_TIME * 3600 ))
+      # Run sleep in background and wait so the trap fires immediately
+      sleep $(( AUDIT_SCHEDULE_TIME * 3600 )) &
+      wait $!
     done
     ;;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,6 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["seadexarr*"]

--- a/seadexarr/modules/anilist.py
+++ b/seadexarr/modules/anilist.py
@@ -41,6 +41,16 @@ def get_query(al_id):
     return j
 
 
+def _media(j: dict) -> dict:
+    """Safely extract the Media object from an AniList response.
+
+    AniList returns {"data": null} for removed/incomplete entries.
+    dict.get(key, {}) only uses the default when the key is absent,
+    not when it exists with a null value — so we use `or {}` guards.
+    """
+    return ((j.get("data") or {}).get("Media") or {})
+
+
 def get_anilist_n_eps(
     al_id,
     al_cache=None,
@@ -64,7 +74,7 @@ def get_anilist_n_eps(
         al_cache[al_id] = copy.deepcopy(j)
 
     # Pull out number of episodes
-    n_eps = j.get("data", {}).get("Media", {}).get("episodes", None)
+    n_eps = _media(j).get("episodes", None)
 
     return n_eps, al_cache
 
@@ -92,9 +102,8 @@ def get_anilist_title(
         al_cache[al_id] = copy.deepcopy(j)
 
     # Prefer the english title, but fall back to romaji
-    title = j.get("data", {}).get("Media", {}).get("title", {}).get("english", None)
-    if title is None:
-        title = j.get("data", {}).get("Media", {}).get("title", {}).get("romaji", None)
+    title_obj = (_media(j).get("title") or {})
+    title = title_obj.get("english") or title_obj.get("romaji")
 
     return title, al_cache
 
@@ -121,7 +130,7 @@ def get_anilist_thumb(
         j = get_query(al_id)
         al_cache[al_id] = copy.deepcopy(j)
 
-    thumb = j.get("data", {}).get("Media", {}).get("coverImage", {}).get("large", None)
+    thumb = (_media(j).get("coverImage") or {}).get("large", None)
 
     return thumb, al_cache
 
@@ -148,6 +157,6 @@ def get_anilist_format(
         j = get_query(al_id)
         al_cache[al_id] = copy.deepcopy(j)
 
-    al_format = j.get("data", {}).get("Media", {}).get("format", None)
+    al_format = _media(j).get("format", None)
 
     return al_format, al_cache

--- a/seadexarr/modules/anilist.py
+++ b/seadexarr/modules/anilist.py
@@ -36,6 +36,7 @@ def _make_session() -> requests.Session:
         read=2,
         backoff_factor=1,
         allowed_methods={"POST"},
+        status_forcelist={429, 500, 502, 503, 504},
         raise_on_status=False,
     )
     adapter = HTTPAdapter(max_retries=retry)

--- a/seadexarr/modules/anilist.py
+++ b/seadexarr/modules/anilist.py
@@ -1,8 +1,11 @@
 import copy
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 API_URL = "https://graphql.anilist.co"
+_TIMEOUT = 30
 
 # AniList query
 QUERY = """
@@ -25,20 +28,43 @@ query ($id: Int) {
 """
 
 
+def _make_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        connect=3,
+        read=2,
+        backoff_factor=1,
+        allowed_methods={"POST"},
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+_SESSION = _make_session()
+
+
 def get_query(al_id):
     """Do the AniList query
 
     Args:
         al_id (int): Anilist ID
+
+    Raises:
+        requests.exceptions.RequestException: on network failure after retries
     """
 
-    # Define query variables and values that will be used in the query request
     variables = {"id": al_id}
-
-    resp = requests.post(API_URL, json={"query": QUERY, "variables": variables})
-    j = resp.json()
-
-    return j
+    resp = _SESSION.post(
+        API_URL,
+        json={"query": QUERY, "variables": variables},
+        timeout=_TIMEOUT,
+    )
+    resp.raise_for_status()
+    return resp.json()
 
 
 def _media(j: dict) -> dict:
@@ -70,7 +96,10 @@ def get_anilist_n_eps(
 
     # If we don't have it, do the query
     if j is None:
-        j = get_query(al_id)
+        try:
+            j = get_query(al_id)
+        except requests.exceptions.RequestException:
+            return None, al_cache
         al_cache[al_id] = copy.deepcopy(j)
 
     # Pull out number of episodes
@@ -98,7 +127,10 @@ def get_anilist_title(
 
     # If we don't have it, do the query
     if j is None:
-        j = get_query(al_id)
+        try:
+            j = get_query(al_id)
+        except requests.exceptions.RequestException:
+            return None, al_cache
         al_cache[al_id] = copy.deepcopy(j)
 
     # Prefer the english title, but fall back to romaji
@@ -127,7 +159,10 @@ def get_anilist_thumb(
 
     # If we don't have it, do the query
     if j is None:
-        j = get_query(al_id)
+        try:
+            j = get_query(al_id)
+        except requests.exceptions.RequestException:
+            return None, al_cache
         al_cache[al_id] = copy.deepcopy(j)
 
     thumb = (_media(j).get("coverImage") or {}).get("large", None)
@@ -154,7 +189,10 @@ def get_anilist_format(
 
     # If we don't have it, do the query
     if j is None:
-        j = get_query(al_id)
+        try:
+            j = get_query(al_id)
+        except requests.exceptions.RequestException:
+            return None, al_cache
         al_cache[al_id] = copy.deepcopy(j)
 
     al_format = _media(j).get("format", None)

--- a/seadexarr/modules/audit.py
+++ b/seadexarr/modules/audit.py
@@ -55,6 +55,8 @@ class SeaDexAudit(SeaDexSonarr):
     def __init__(self, config: str, cache: str, logger=None):
         super().__init__(config=config, cache=cache, logger=logger)
 
+        self.audit_mode = True
+
         audit_cfg = self.config.get("audit", {}) or {}
         self.audit_dry_run: bool = audit_cfg.get("dry_run", True)
         self.audit_notify_discord: bool = audit_cfg.get("notify_discord", True)

--- a/seadexarr/modules/audit.py
+++ b/seadexarr/modules/audit.py
@@ -382,12 +382,23 @@ class SeaDexAudit(SeaDexSonarr):
         out["seadex_size_bytes"] = self._sum_seadex_size(seadex_dict)
 
         seadex_dict = self.parse_episodes_from_seadex(seadex_dict=seadex_dict)
+
+        # Does the library already hold a SeaDex-listed release (best OR alt)?
+        # When alt_is_acceptable, this both rescues the upgrade flag below and
+        # stops filter_seadex_downloads from logging a misleading "tagging" line
+        # for a series we won't actually flag.
+        acceptable_alt_owned = self.alt_is_acceptable and self._library_has_seadex_rg(
+            sd_entry=sd_entry,
+            library_rgs=out["library_rgs"],
+        )
+
         _, seadex_dict = self.filter_seadex_downloads(
             al_id=al_id,
             seadex_dict=seadex_dict,
             arr="sonarr",
             arr_release_dict=sonarr_release_dict,
             ep_list=ep_list,
+            acceptable_alt_owned=acceptable_alt_owned,
         )
         out["upgrade_available"] = self.get_any_to_download(seadex_dict=seadex_dict)
 
@@ -400,20 +411,25 @@ class SeaDexAudit(SeaDexSonarr):
 
         # If alt releases are acceptable and the library already has any
         # SeaDex-listed release (best OR alt), don't flag for upgrade.
-        if (out["upgrade_available"] or out["too_large"]) and self.alt_is_acceptable:
-            all_candidates = [
-                t for t in sd_entry.torrents
-                if not set(self.ignore_tags) & set(t.tags)
-                and t.tracker.lower() in self.trackers
-            ]
-            if self.public_only:
-                all_candidates = [t for t in all_candidates if t.tracker.is_public()]
-            all_sd_rgs = {t.release_group for t in all_candidates}
-            if set(out["library_rgs"]) & all_sd_rgs:
-                out["upgrade_available"] = False
-                out["too_large"] = False
+        if (out["upgrade_available"] or out["too_large"]) and acceptable_alt_owned:
+            out["upgrade_available"] = False
+            out["too_large"] = False
 
         return out
+
+    def _library_has_seadex_rg(self, sd_entry, library_rgs) -> bool:
+        """True if the library holds any SeaDex-listed release group (best or
+        alt), honoring the same tracker/public/ignore-tag filters as
+        get_seadex_dict so acceptability matches what we'd actually grab."""
+        candidates = [
+            t for t in sd_entry.torrents
+            if not set(self.ignore_tags) & set(t.tags)
+            and t.tracker.lower() in self.trackers
+        ]
+        if self.public_only:
+            candidates = [t for t in candidates if t.tracker.is_public()]
+        all_sd_rgs = {t.release_group for t in candidates}
+        return bool(set(library_rgs) & all_sd_rgs)
 
     # ------------------------------------------------------------------
     # Tags

--- a/seadexarr/modules/audit.py
+++ b/seadexarr/modules/audit.py
@@ -80,6 +80,7 @@ class SeaDexAudit(SeaDexSonarr):
         self.max_absolute_gb: float = size_cfg.get("max_absolute_gb", 80)
         self.max_size_multiplier: float = size_cfg.get("max_size_multiplier", 2.0)
         self.tag_when_too_large: bool = size_cfg.get("tag_when_too_large", True)
+        self.alt_is_acceptable: bool = audit_cfg.get("alt_is_acceptable", False)
 
         self.discord_cfg: dict = audit_cfg.get("discord", {}) or {}
 
@@ -309,6 +310,7 @@ class SeaDexAudit(SeaDexSonarr):
             result.desired_tags = self._compute_desired_tags(result)
 
         except Exception as e:
+            import traceback as _tb
             result.error = str(e)
             self.logger.error(
                 left_aligned_string(
@@ -316,6 +318,9 @@ class SeaDexAudit(SeaDexSonarr):
                     total_length=self.log_line_length,
                 )
             )
+            for tb_line in _tb.format_exc().splitlines():
+                if tb_line.strip():
+                    self.logger.error(f"  {tb_line}")
 
         return result
 
@@ -381,6 +386,21 @@ class SeaDexAudit(SeaDexSonarr):
             ratio = (out["seadex_size_bytes"] / lib_bytes) if lib_bytes > 0 else 0
             if sd_gb > self.max_absolute_gb or ratio > self.max_size_multiplier:
                 out["too_large"] = True
+
+        # If alt releases are acceptable and the library already has any
+        # SeaDex-listed release (best OR alt), don't flag for upgrade.
+        if (out["upgrade_available"] or out["too_large"]) and self.alt_is_acceptable:
+            all_candidates = [
+                t for t in sd_entry.torrents
+                if not set(self.ignore_tags) & set(t.tags)
+                and t.tracker.lower() in self.trackers
+            ]
+            if self.public_only:
+                all_candidates = [t for t in all_candidates if t.tracker.is_public()]
+            all_sd_rgs = {t.release_group for t in all_candidates}
+            if set(out["library_rgs"]) & all_sd_rgs:
+                out["upgrade_available"] = False
+                out["too_large"] = False
 
         return out
 
@@ -586,8 +606,8 @@ class SeaDexAudit(SeaDexSonarr):
     def _sum_seadex_size(self, seadex_dict: dict) -> int:
         total = 0
         for rg_data in seadex_dict.values():
-            for url_data in rg_data.get("urls", {}).values():
-                sizes = url_data.get("size", []) or []
+            for url_data in (rg_data.get("urls") or {}).values():
+                sizes = (url_data or {}).get("size", []) or []
                 total += sum(s for s in sizes if s)
         return total
 

--- a/seadexarr/modules/audit.py
+++ b/seadexarr/modules/audit.py
@@ -60,6 +60,11 @@ class SeaDexAudit(SeaDexSonarr):
         self.audit_notify_discord: bool = audit_cfg.get("notify_discord", True)
         self.audit_update_tags: bool = audit_cfg.get("update_sonarr_tags", True)
         self.audit_remove_stale: bool = audit_cfg.get("remove_stale_tags", False)
+        if self.audit_remove_stale:
+            self.logger.warning(
+                "Config: remove_stale_tags has no effect — managed tags are always "
+                "synced and user-added non-managed tags are always preserved"
+            )
 
         tags_cfg = audit_cfg.get("tags", {}) or {}
         self.tag_full: str = tags_cfg.get("full_seadex", "seadex")
@@ -216,10 +221,17 @@ class SeaDexAudit(SeaDexSonarr):
                 changed = self._apply_series_tags(series, result, dry_run=False)
                 if changed:
                     stats["tagged"] += 1
-            elif dry_run:
+            elif dry_run and do_tags:
                 self._log_dry_run_tags(result)
 
             time.sleep(self.sleep_time)
+
+        # Persist state before notifications so a crash during Discord doesn't
+        # leave all audited series looking new on the next run.
+        if self.audit_state is not None and not dry_run:
+            for r in results:
+                if not r.error:
+                    self.audit_state.update_series(self._to_state(r), notified=False)
 
         # Notifications
         to_notify = [r for r in results if r.notify and r.seadex_status != "none"]
@@ -231,15 +243,11 @@ class SeaDexAudit(SeaDexSonarr):
                     self._send_single_discord(r, old_states.get(r.sonarr_id))
             stats["notified"] = len(to_notify)
 
-        # Persist state
+        # Update last_notified for series that Discord was actually sent for
         if self.audit_state is not None and not dry_run:
-            notified_ids = {r.sonarr_id for r in to_notify}
-            for r in results:
+            for r in to_notify:
                 if not r.error:
-                    self.audit_state.update_series(
-                        self._to_state(r),
-                        notified=r.sonarr_id in notified_ids,
-                    )
+                    self.audit_state.update_series(self._to_state(r), notified=True)
             self.audit_state.save()
 
         self._log_summary(stats)
@@ -363,8 +371,9 @@ class SeaDexAudit(SeaDexSonarr):
         seadex_dict = self.get_seadex_dict(sd_entry=sd_entry)
 
         if len(seadex_dict) == 0:
-            out["seadex_status"] = "partial"
-            return out
+            # SeaDex has an entry but all torrents were filtered by the user's
+            # tracker/public_only/want_best config — no actionable release exists.
+            return out  # seadex_status stays "none"
 
         out["seadex_status"] = "full"
         out["seadex_rgs"] = list(seadex_dict.keys())
@@ -541,8 +550,7 @@ class SeaDexAudit(SeaDexSonarr):
             al_cache=self.al_cache,
         )
 
-        discord = Discord(url=self.discord_url)
-        discord.post(embeds=[{
+        embed: dict = {
             "author": {
                 "name": "SeaDexArr Audit",
                 "url": "https://github.com/bbtufty/seadexarr",
@@ -551,8 +559,12 @@ class SeaDexAudit(SeaDexSonarr):
             "description": result.sd_url or "",
             "color": self._embed_colour(result),
             "fields": fields,
-            "thumbnail": {"url": anilist_thumb},
-        }])
+        }
+        if anilist_thumb:
+            embed["thumbnail"] = {"url": anilist_thumb}
+
+        discord = Discord(url=self.discord_url)
+        discord.post(embeds=[embed])
         time.sleep(1)
 
     def _send_batch_discord(

--- a/seadexarr/modules/audit.py
+++ b/seadexarr/modules/audit.py
@@ -1,0 +1,529 @@
+"""
+Audit-only mode for SeaDexArr.
+
+Scans Sonarr, classifies SeaDex coverage, applies tags, sends Discord
+notifications. Never calls add_torrent() or any torrent-client method.
+"""
+
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from discordwebhook import Discord
+
+from .anilist import get_anilist_thumb
+from .audit_state import AuditState, SeriesAuditState
+from .log import centred_string, left_aligned_string
+from .seadex_sonarr import SeaDexSonarr
+from .sonarr_tags import SonarrTagManager
+
+BYTES_PER_GB = 1_073_741_824
+
+
+@dataclass
+class AuditResult:
+    sonarr_id: int
+    tvdb_id: Optional[int]
+    sonarr_title: str
+    anilist_title: str
+    al_id: Optional[int]
+    sd_url: Optional[str]
+    seadex_status: str          # none / partial / full
+    seadex_rgs: list[str] = field(default_factory=list)
+    seadex_size_bytes: int = 0
+    library_rgs: list[str] = field(default_factory=list)
+    library_size_bytes: int = 0
+    upgrade_available: bool = False
+    too_large: bool = False
+    desired_tags: list[str] = field(default_factory=list)
+    notify: bool = False
+    error: Optional[str] = None
+
+
+class SeaDexAudit(SeaDexSonarr):
+    """Audit-only SeaDex scanner. Extends SeaDexSonarr but never grabs torrents."""
+
+    def __init__(self, config: str, cache: str, logger=None):
+        super().__init__(config=config, cache=cache, logger=logger)
+
+        audit_cfg = self.config.get("audit", {}) or {}
+        self.audit_notify_discord: bool = audit_cfg.get("notify_discord", True)
+        self.audit_update_tags: bool = audit_cfg.get("update_sonarr_tags", True)
+        self.audit_remove_stale: bool = audit_cfg.get("remove_stale_tags", False)
+
+        tags_cfg = audit_cfg.get("tags", {}) or {}
+        self.tag_full: str = tags_cfg.get("full_seadex", "seadex")
+        self.tag_partial: str = tags_cfg.get("partial_seadex", "partial-seadex")
+        self.tag_upgrade: str = tags_cfg.get("upgrade_available", "seadex-upgrade-available")
+        self.tag_too_large: str = tags_cfg.get("too_large", "seadex-too-large")
+        self.tag_ignored: str = tags_cfg.get("ignored", "seadex-ignored")
+        self.managed_tag_labels: list[str] = [
+            self.tag_full,
+            self.tag_partial,
+            self.tag_upgrade,
+            self.tag_too_large,
+            self.tag_ignored,
+        ]
+
+        size_cfg = audit_cfg.get("size_filters", {}) or {}
+        self.size_filter_enabled: bool = size_cfg.get("enabled", True)
+        self.max_absolute_gb: float = size_cfg.get("max_absolute_gb", 80)
+        self.max_size_multiplier: float = size_cfg.get("max_size_multiplier", 2.0)
+        self.tag_when_too_large: bool = size_cfg.get("tag_when_too_large", True)
+
+        self.discord_cfg: dict = audit_cfg.get("discord", {}) or {}
+
+        state_cfg = audit_cfg.get("state", {}) or {}
+        self.state_enabled: bool = state_cfg.get("enabled", True)
+        state_path: str = state_cfg.get("path") or "/config/audit_state.json"
+        self.audit_state: Optional[AuditState] = (
+            AuditState(state_path) if self.state_enabled else None
+        )
+
+        self.tag_manager = SonarrTagManager(
+            sonarr_url=self.sonarr_url,
+            sonarr_api_key=self.sonarr_api_key,
+        )
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        dry_run: bool = False,
+        apply_tags: bool = False,
+        notify_only: bool = False,
+    ) -> bool:
+        """Audit Sonarr library against SeaDex. Never adds torrents.
+
+        Args:
+            dry_run: Log intended changes only; no Sonarr or state mutations.
+            apply_tags: Apply computed Sonarr tags (overrides audit.dry_run).
+            notify_only: Send Discord notifications without changing tags.
+        """
+        all_series = self.get_all_sonarr_series()
+        n_total = len(all_series)
+
+        self.log_arr_start(arr="sonarr", n_items=n_total)
+
+        stats: dict[str, int] = {
+            "total": n_total,
+            "matched": 0,
+            "full": 0,
+            "partial": 0,
+            "upgrade": 0,
+            "too_large": 0,
+            "tagged": 0,
+            "notified": 0,
+            "errors": 0,
+        }
+
+        results: list[AuditResult] = []
+
+        for idx, series in enumerate(all_series):
+            self.log_arr_item_start(
+                arr="sonarr",
+                item_title=series.title,
+                n_item=idx + 1,
+                n_items=n_total,
+            )
+
+            result = self._audit_series(series)
+            results.append(result)
+
+            if result.error:
+                stats["errors"] += 1
+                time.sleep(self.sleep_time)
+                continue
+
+            if result.seadex_status != "none":
+                stats["matched"] += 1
+            if result.seadex_status == "full":
+                stats["full"] += 1
+            elif result.seadex_status == "partial":
+                stats["partial"] += 1
+            if result.upgrade_available:
+                stats["upgrade"] += 1
+            if result.too_large:
+                stats["too_large"] += 1
+
+            self._log_result(result)
+
+            # Determine notification need
+            if self.audit_state is not None:
+                result.notify = self.audit_state.should_notify(
+                    new_state=self._to_state(result),
+                    discord_cfg=self.discord_cfg,
+                )
+            else:
+                result.notify = result.seadex_status != "none"
+
+            # Tag management
+            do_tags = (apply_tags or self.audit_update_tags) and not notify_only
+            if do_tags and not dry_run:
+                changed = self._apply_series_tags(series, result, dry_run=False)
+                if changed:
+                    stats["tagged"] += 1
+            elif dry_run:
+                self._log_dry_run_tags(result)
+
+            time.sleep(self.sleep_time)
+
+        # Notifications
+        to_notify = [r for r in results if r.notify and r.seadex_status != "none"]
+        if to_notify and (self.audit_notify_discord or notify_only) and self.discord_url:
+            if self.discord_cfg.get("batch_notifications", True):
+                self._send_batch_discord(to_notify)
+            else:
+                for r in to_notify:
+                    self._send_single_discord(r)
+            stats["notified"] = len(to_notify)
+
+        # Persist state
+        if self.audit_state is not None and not dry_run:
+            notified_ids = {r.sonarr_id for r in to_notify}
+            for r in results:
+                if not r.error:
+                    self.audit_state.update_series(
+                        self._to_state(r),
+                        notified=r.sonarr_id in notified_ids,
+                    )
+            self.audit_state.save()
+
+        self._log_summary(stats)
+        return True
+
+    # ------------------------------------------------------------------
+    # Per-series audit
+    # ------------------------------------------------------------------
+
+    def _audit_series(self, sonarr_series) -> AuditResult:
+        result = AuditResult(
+            sonarr_id=sonarr_series.id,
+            tvdb_id=sonarr_series.tvdbId,
+            sonarr_title=sonarr_series.title,
+            anilist_title=sonarr_series.title,
+            al_id=None,
+            sd_url=None,
+            seadex_status="none",
+        )
+
+        try:
+            al_mappings = self.get_anilist_ids(
+                tvdb_id=sonarr_series.tvdbId,
+                imdb_id=sonarr_series.imdbId,
+            )
+            if not al_mappings:
+                return result
+
+            # Evaluate each AniList mapping; aggregate to series-level result
+            per_al: list[dict] = []
+            for al_id, mapping in al_mappings.items():
+                if al_id is None:
+                    continue
+                per_al.append(self._audit_al_id(sonarr_series, al_id, mapping))
+
+            if not per_al:
+                return result
+
+            # Consolidate: propagate the most informative status upward
+            STATUS_ORDER = ["none", "partial", "full"]
+
+            best = max(per_al, key=lambda d: STATUS_ORDER.index(d["seadex_status"]))
+            result.al_id = best["al_id"]
+            result.sd_url = best["sd_url"]
+            result.anilist_title = best["anilist_title"]
+            result.seadex_status = best["seadex_status"]
+            result.seadex_rgs = best["seadex_rgs"]
+            result.seadex_size_bytes = best["seadex_size_bytes"]
+            result.library_rgs = best["library_rgs"]
+            result.library_size_bytes = best["library_size_bytes"]
+            result.upgrade_available = any(d["upgrade_available"] for d in per_al)
+            result.too_large = any(d["too_large"] for d in per_al)
+            result.desired_tags = self._compute_desired_tags(result)
+
+        except Exception as e:
+            result.error = str(e)
+            self.logger.error(
+                left_aligned_string(
+                    f"Error auditing {sonarr_series.title}: {e}",
+                    total_length=self.log_line_length,
+                )
+            )
+
+        return result
+
+    def _audit_al_id(self, sonarr_series, al_id: int, mapping: dict) -> dict:
+        """Audit a single AniList ID for a Sonarr series."""
+        out: dict = {
+            "al_id": al_id,
+            "sd_url": None,
+            "anilist_title": sonarr_series.title,
+            "seadex_status": "none",
+            "seadex_rgs": [],
+            "seadex_size_bytes": 0,
+            "library_rgs": [],
+            "library_size_bytes": 0,
+            "upgrade_available": False,
+            "too_large": False,
+        }
+
+        sd_entry = self.get_seadex_entry(al_id=al_id)
+        if sd_entry is None:
+            return out
+
+        out["sd_url"] = sd_entry.url
+        out["anilist_title"] = self.get_anilist_title(al_id=al_id, sd_entry=sd_entry)
+
+        ep_list = self.get_ep_list(
+            sonarr_series_id=sonarr_series.id,
+            al_id=al_id,
+            mapping=mapping,
+        )
+        if ep_list is None:
+            ep_list = []
+
+        sonarr_release_dict = self.get_sonarr_release_dict(ep_list=ep_list)
+        out["library_rgs"] = list(sonarr_release_dict.keys())
+        out["library_size_bytes"] = sum(
+            sum(s for s in rg_data.get("size", []) if s)
+            for rg_data in sonarr_release_dict.values()
+        )
+
+        seadex_dict = self.get_seadex_dict(sd_entry=sd_entry)
+
+        if len(seadex_dict) == 0:
+            # SeaDex entry exists but nothing passes user filters → partial
+            out["seadex_status"] = "partial"
+            return out
+
+        out["seadex_status"] = "full"
+        out["seadex_rgs"] = list(seadex_dict.keys())
+        out["seadex_size_bytes"] = self._sum_seadex_size(seadex_dict)
+
+        # Check upgrade
+        seadex_dict = self.parse_episodes_from_seadex(seadex_dict=seadex_dict)
+        _, seadex_dict = self.filter_seadex_downloads(
+            al_id=al_id,
+            seadex_dict=seadex_dict,
+            arr="sonarr",
+            arr_release_dict=sonarr_release_dict,
+            ep_list=ep_list,
+        )
+        out["upgrade_available"] = self.get_any_to_download(seadex_dict=seadex_dict)
+
+        # Size check
+        if out["upgrade_available"] and self.size_filter_enabled:
+            sd_gb = out["seadex_size_bytes"] / BYTES_PER_GB
+            lib_bytes = out["library_size_bytes"]
+            ratio = (out["seadex_size_bytes"] / lib_bytes) if lib_bytes > 0 else 0
+            if sd_gb > self.max_absolute_gb or ratio > self.max_size_multiplier:
+                out["too_large"] = True
+
+        return out
+
+    # ------------------------------------------------------------------
+    # Tags
+    # ------------------------------------------------------------------
+
+    def _compute_desired_tags(self, result: AuditResult) -> list[str]:
+        tags: list[str] = []
+        if result.seadex_status == "full":
+            tags.append(self.tag_full)
+        elif result.seadex_status == "partial":
+            tags.append(self.tag_partial)
+
+        if result.upgrade_available:
+            if result.too_large and self.tag_when_too_large:
+                tags.append(self.tag_too_large)
+            else:
+                tags.append(self.tag_upgrade)
+
+        return tags
+
+    def _apply_series_tags(self, sonarr_series, result: AuditResult, dry_run: bool) -> bool:
+        try:
+            series_json = self.tag_manager.get_series_json(sonarr_series.id)
+            current_tags = series_json.get("tags", [])
+
+            new_tags, changed = self.tag_manager.compute_tag_changes(
+                current_tag_ids=current_tags,
+                desired_labels=result.desired_tags,
+                managed_labels=self.managed_tag_labels,
+                remove_stale=self.audit_remove_stale,
+            )
+
+            if changed:
+                self.tag_manager.set_series_tags(sonarr_series.id, new_tags, dry_run=dry_run)
+                self.logger.info(
+                    centred_string(
+                        f"Tags updated for {result.sonarr_title}: {result.desired_tags}",
+                        total_length=self.log_line_length,
+                    )
+                )
+            return changed
+        except Exception as e:
+            self.logger.error(
+                left_aligned_string(
+                    f"Tag update failed for {result.sonarr_title}: {e}",
+                    total_length=self.log_line_length,
+                )
+            )
+            return False
+
+    def _log_dry_run_tags(self, result: AuditResult):
+        self.logger.info(
+            centred_string(
+                f"[DRY RUN] {result.sonarr_title} → tags: {result.desired_tags}",
+                total_length=self.log_line_length,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Discord
+    # ------------------------------------------------------------------
+
+    def _send_single_discord(self, result: AuditResult):
+        if not self.discord_url:
+            return
+
+        sd_gb = result.seadex_size_bytes / BYTES_PER_GB
+        lib_gb = result.library_size_bytes / BYTES_PER_GB
+        delta_gb = sd_gb - lib_gb
+
+        fields = [
+            {"name": "Coverage", "value": result.seadex_status.capitalize(), "inline": True},
+            {"name": "Current", "value": ", ".join(result.library_rgs) or "None", "inline": True},
+            {"name": "SeaDex", "value": ", ".join(result.seadex_rgs) or "None", "inline": True},
+        ]
+
+        if result.upgrade_available:
+            size_str = f"{sd_gb:.1f} GB ({delta_gb:+.1f} GB vs current)"
+            if result.library_size_bytes > 0:
+                size_str += f" / {result.seadex_size_bytes / result.library_size_bytes:.1f}× current"
+            fields.append({"name": "Size", "value": size_str, "inline": False})
+
+        if result.too_large:
+            action = f"Flagged too large — tagged `{self.tag_too_large}`; no download performed"
+        elif result.upgrade_available:
+            action = f"Tagged `{self.tag_upgrade}`; no download performed"
+        else:
+            action = "Already have recommended release"
+        fields.append({"name": "Action", "value": action, "inline": False})
+
+        if result.sd_url:
+            fields.append({"name": "SeaDex entry", "value": result.sd_url, "inline": False})
+
+        anilist_thumb, self.al_cache = get_anilist_thumb(
+            al_id=result.al_id,
+            al_cache=self.al_cache,
+        )
+
+        discord = Discord(url=self.discord_url)
+        discord.post(embeds=[{
+            "author": {
+                "name": "SeaDexArr Audit",
+                "url": "https://github.com/bbtufty/seadexarr",
+            },
+            "title": result.anilist_title or result.sonarr_title,
+            "description": result.sd_url or "",
+            "fields": fields,
+            "thumbnail": {"url": anilist_thumb},
+        }])
+        time.sleep(1)
+
+    def _send_batch_discord(self, results: list[AuditResult]):
+        if not self.discord_url or not results:
+            return
+
+        BATCH_SIZE = 10  # Discord API maximum embeds per message
+        for i in range(0, len(results), BATCH_SIZE):
+            batch = results[i : i + BATCH_SIZE]
+            embeds = []
+            for r in batch:
+                sd_gb = r.seadex_size_bytes / BYTES_PER_GB
+                lib_gb = r.library_size_bytes / BYTES_PER_GB
+                delta_gb = sd_gb - lib_gb
+
+                parts = [f"Coverage: {r.seadex_status.capitalize()}"]
+                if r.library_rgs:
+                    parts.append(f"Current: {', '.join(r.library_rgs)}")
+                if r.seadex_rgs:
+                    parts.append(f"SeaDex: {', '.join(r.seadex_rgs)}")
+                if r.upgrade_available:
+                    flag = " ⚠ Too Large" if r.too_large else " ↑ Upgrade"
+                    parts.append(f"Size: {sd_gb:.1f} GB ({delta_gb:+.1f} GB){flag}")
+
+                embeds.append({
+                    "author": {"name": "SeaDexArr Audit"},
+                    "title": r.anilist_title or r.sonarr_title,
+                    "description": "\n".join(parts),
+                    "url": r.sd_url or "",
+                })
+
+            discord = Discord(url=self.discord_url)
+            discord.post(embeds=embeds)
+            time.sleep(1)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _sum_seadex_size(self, seadex_dict: dict) -> int:
+        total = 0
+        for rg_data in seadex_dict.values():
+            for url_data in rg_data.get("urls", {}).values():
+                sizes = url_data.get("size", []) or []
+                total += sum(s for s in sizes if s)
+        return total
+
+    def _to_state(self, result: AuditResult) -> SeriesAuditState:
+        return SeriesAuditState(
+            sonarr_id=result.sonarr_id,
+            tvdb_id=result.tvdb_id,
+            title=result.sonarr_title,
+            seadex_status=result.seadex_status,
+            seadex_rgs=result.seadex_rgs,
+            seadex_size_bytes=result.seadex_size_bytes,
+            library_rgs=result.library_rgs,
+            upgrade_available=result.upgrade_available,
+            too_large=result.too_large,
+        )
+
+    def _log_result(self, result: AuditResult):
+        status_str = result.seadex_status
+        if result.upgrade_available:
+            status_str += " | upgrade-available"
+        if result.too_large:
+            status_str += " | too-large"
+        self.logger.info(
+            centred_string(
+                f"{result.sonarr_title}: {status_str}",
+                total_length=self.log_line_length,
+            )
+        )
+
+    def _log_summary(self, stats: dict[str, int]):
+        sep = "=" * self.log_line_length
+        self.logger.info(centred_string(sep, total_length=self.log_line_length))
+        self.logger.info(centred_string("Audit Summary", total_length=self.log_line_length))
+        self.logger.info(centred_string(sep, total_length=self.log_line_length))
+        for label, key in [
+            ("Scanned", "total"),
+            ("Matched to SeaDex", "matched"),
+            ("Full coverage", "full"),
+            ("Partial coverage", "partial"),
+            ("Upgrade available", "upgrade"),
+            ("Too large", "too_large"),
+            ("Tags updated", "tagged"),
+            ("Notifications sent", "notified"),
+            ("Errors", "errors"),
+        ]:
+            self.logger.info(
+                centred_string(
+                    f"{label}: {stats[key]}",
+                    total_length=self.log_line_length,
+                )
+            )
+        self.logger.info(centred_string(sep, total_length=self.log_line_length))

--- a/seadexarr/modules/audit.py
+++ b/seadexarr/modules/audit.py
@@ -5,6 +5,8 @@ Scans Sonarr, classifies SeaDex coverage, applies tags, sends Discord
 notifications. Never calls add_torrent() or any torrent-client method.
 """
 
+import signal
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Optional
@@ -12,12 +14,19 @@ from typing import Optional
 from discordwebhook import Discord
 
 from .anilist import get_anilist_thumb
-from .audit_state import AuditState, SeriesAuditState
+from .audit_state import AuditState, SeriesAuditState, rg_diff, state_changed
 from .log import centred_string, left_aligned_string
 from .seadex_sonarr import SeaDexSonarr
 from .sonarr_tags import SonarrTagManager
 
 BYTES_PER_GB = 1_073_741_824
+
+# Discord embed colours
+_COLOUR_FULL = 0x2ECC71      # green
+_COLOUR_PARTIAL = 0xF1C40F   # yellow
+_COLOUR_UPGRADE = 0xE67E22   # orange
+_COLOUR_TOO_LARGE = 0xE74C3C # red
+_COLOUR_NONE = 0x95A5A6      # grey
 
 
 @dataclass
@@ -47,6 +56,7 @@ class SeaDexAudit(SeaDexSonarr):
         super().__init__(config=config, cache=cache, logger=logger)
 
         audit_cfg = self.config.get("audit", {}) or {}
+        self.audit_dry_run: bool = audit_cfg.get("dry_run", True)
         self.audit_notify_discord: bool = audit_cfg.get("notify_discord", True)
         self.audit_update_tags: bool = audit_cfg.get("update_sonarr_tags", True)
         self.audit_remove_stale: bool = audit_cfg.get("remove_stale_tags", False)
@@ -75,7 +85,7 @@ class SeaDexAudit(SeaDexSonarr):
 
         state_cfg = audit_cfg.get("state", {}) or {}
         self.state_enabled: bool = state_cfg.get("enabled", True)
-        state_path: str = state_cfg.get("path") or "/config/audit_state.json"
+        state_path: str = state_cfg.get("path") or "/config/audit_state.db"
         self.audit_state: Optional[AuditState] = (
             AuditState(state_path) if self.state_enabled else None
         )
@@ -99,9 +109,35 @@ class SeaDexAudit(SeaDexSonarr):
 
         Args:
             dry_run: Log intended changes only; no Sonarr or state mutations.
-            apply_tags: Apply computed Sonarr tags (overrides audit.dry_run).
+            apply_tags: Explicitly override config dry_run and apply tags.
             notify_only: Send Discord notifications without changing tags.
         """
+        # Config dry_run is the safety default. --apply-tags overrides it;
+        # --dry-run always wins regardless of config.
+        if dry_run:
+            effective_dry_run = True
+        elif apply_tags:
+            effective_dry_run = False
+        else:
+            effective_dry_run = self.audit_dry_run
+        dry_run = effective_dry_run
+
+        # Graceful shutdown: SIGTERM/SIGINT finishes the current al_id then exits.
+        # Stored on self so _audit_series can check between al_id iterations.
+        self._shutdown = threading.Event()
+
+        def _handle_signal(sig, frame):
+            self.logger.warning(
+                left_aligned_string(
+                    "Shutdown signal received — finishing current series then saving state.",
+                    total_length=self.log_line_length,
+                )
+            )
+            self._shutdown.set()
+
+        signal.signal(signal.SIGTERM, _handle_signal)
+        signal.signal(signal.SIGINT, _handle_signal)
+
         all_series = self.get_all_sonarr_series()
         n_total = len(all_series)
 
@@ -120,14 +156,29 @@ class SeaDexAudit(SeaDexSonarr):
         }
 
         results: list[AuditResult] = []
+        # old_states keyed by sonarr_id — captured before any update_series call
+        old_states: dict[int, Optional[SeriesAuditState]] = {}
 
         for idx, series in enumerate(all_series):
+            if self._shutdown.is_set():
+                self.logger.info(
+                    left_aligned_string(
+                        f"Audit interrupted after {idx}/{n_total} series.",
+                        total_length=self.log_line_length,
+                    )
+                )
+                break
+
             self.log_arr_item_start(
                 arr="sonarr",
                 item_title=series.title,
                 n_item=idx + 1,
                 n_items=n_total,
             )
+
+            # Snapshot old state before this audit run
+            if self.audit_state is not None:
+                old_states[series.id] = self.audit_state.get_series(series.id)
 
             result = self._audit_series(series)
             results.append(result)
@@ -150,7 +201,6 @@ class SeaDexAudit(SeaDexSonarr):
 
             self._log_result(result)
 
-            # Determine notification need
             if self.audit_state is not None:
                 result.notify = self.audit_state.should_notify(
                     new_state=self._to_state(result),
@@ -174,10 +224,10 @@ class SeaDexAudit(SeaDexSonarr):
         to_notify = [r for r in results if r.notify and r.seadex_status != "none"]
         if to_notify and (self.audit_notify_discord or notify_only) and self.discord_url:
             if self.discord_cfg.get("batch_notifications", True):
-                self._send_batch_discord(to_notify)
+                self._send_batch_discord(to_notify, old_states)
             else:
                 for r in to_notify:
-                    self._send_single_discord(r)
+                    self._send_single_discord(r, old_states.get(r.sonarr_id))
             stats["notified"] = len(to_notify)
 
         # Persist state
@@ -217,9 +267,10 @@ class SeaDexAudit(SeaDexSonarr):
             if not al_mappings:
                 return result
 
-            # Evaluate each AniList mapping; aggregate to series-level result
             per_al: list[dict] = []
             for al_id, mapping in al_mappings.items():
+                if getattr(self, "_shutdown", None) and self._shutdown.is_set():
+                    break
                 if al_id is None:
                     continue
                 per_al.append(self._audit_al_id(sonarr_series, al_id, mapping))
@@ -227,18 +278,32 @@ class SeaDexAudit(SeaDexSonarr):
             if not per_al:
                 return result
 
-            # Consolidate: propagate the most informative status upward
             STATUS_ORDER = ["none", "partial", "full"]
 
-            best = max(per_al, key=lambda d: STATUS_ORDER.index(d["seadex_status"]))
-            result.al_id = best["al_id"]
-            result.sd_url = best["sd_url"]
-            result.anilist_title = best["anilist_title"]
-            result.seadex_status = best["seadex_status"]
-            result.seadex_rgs = best["seadex_rgs"]
-            result.seadex_size_bytes = best["seadex_size_bytes"]
-            result.library_rgs = best["library_rgs"]
-            result.library_size_bytes = best["library_size_bytes"]
+            best_status = max(
+                per_al, key=lambda d: STATUS_ORDER.index(d["seadex_status"])
+            )["seadex_status"]
+
+            # Pick representative entry for URL/title from the highest-status group
+            top_entries = [d for d in per_al if d["seadex_status"] == best_status]
+            representative = top_entries[0]
+
+            result.al_id = representative["al_id"]
+            result.sd_url = representative["sd_url"]
+            result.anilist_title = representative["anilist_title"]
+            result.seadex_status = best_status
+
+            # Union RGs across ALL top-status entries so per-entry changes are
+            # detected even when the aggregate status doesn't change.
+            result.seadex_rgs = sorted(
+                {rg for d in top_entries for rg in d["seadex_rgs"]}
+            )
+            result.seadex_size_bytes = max(
+                (d["seadex_size_bytes"] for d in top_entries), default=0
+            )
+            result.library_rgs = representative["library_rgs"]
+            result.library_size_bytes = representative["library_size_bytes"]
+
             result.upgrade_available = any(d["upgrade_available"] for d in per_al)
             result.too_large = any(d["too_large"] for d in per_al)
             result.desired_tags = self._compute_desired_tags(result)
@@ -255,7 +320,6 @@ class SeaDexAudit(SeaDexSonarr):
         return result
 
     def _audit_al_id(self, sonarr_series, al_id: int, mapping: dict) -> dict:
-        """Audit a single AniList ID for a Sonarr series."""
         out: dict = {
             "al_id": al_id,
             "sd_url": None,
@@ -294,7 +358,6 @@ class SeaDexAudit(SeaDexSonarr):
         seadex_dict = self.get_seadex_dict(sd_entry=sd_entry)
 
         if len(seadex_dict) == 0:
-            # SeaDex entry exists but nothing passes user filters → partial
             out["seadex_status"] = "partial"
             return out
 
@@ -302,7 +365,6 @@ class SeaDexAudit(SeaDexSonarr):
         out["seadex_rgs"] = list(seadex_dict.keys())
         out["seadex_size_bytes"] = self._sum_seadex_size(seadex_dict)
 
-        # Check upgrade
         seadex_dict = self.parse_episodes_from_seadex(seadex_dict=seadex_dict)
         _, seadex_dict = self.filter_seadex_downloads(
             al_id=al_id,
@@ -313,7 +375,6 @@ class SeaDexAudit(SeaDexSonarr):
         )
         out["upgrade_available"] = self.get_any_to_download(seadex_dict=seadex_dict)
 
-        # Size check
         if out["upgrade_available"] and self.size_filter_enabled:
             sd_gb = out["seadex_size_bytes"] / BYTES_PER_GB
             lib_bytes = out["library_size_bytes"]
@@ -384,7 +445,19 @@ class SeaDexAudit(SeaDexSonarr):
     # Discord
     # ------------------------------------------------------------------
 
-    def _send_single_discord(self, result: AuditResult):
+    @staticmethod
+    def _embed_colour(result: AuditResult) -> int:
+        if result.too_large:
+            return _COLOUR_TOO_LARGE
+        if result.upgrade_available:
+            return _COLOUR_UPGRADE
+        if result.seadex_status == "full":
+            return _COLOUR_FULL
+        if result.seadex_status == "partial":
+            return _COLOUR_PARTIAL
+        return _COLOUR_NONE
+
+    def _send_single_discord(self, result: AuditResult, old_state: Optional[SeriesAuditState]):
         if not self.discord_url:
             return
 
@@ -392,11 +465,39 @@ class SeaDexAudit(SeaDexSonarr):
         lib_gb = result.library_size_bytes / BYTES_PER_GB
         delta_gb = sd_gb - lib_gb
 
+        old_s = old_state  # may be None on first ever audit
+        added_rgs, removed_rgs = rg_diff(old_s, self._to_state(result))
+
+        # Status transition label
+        old_status = old_s.seadex_status if old_s else "new"
+        new_status = result.seadex_status.capitalize()
+        if old_s and old_s.seadex_status != result.seadex_status:
+            status_label = f"{old_status.capitalize()} → {new_status}"
+        else:
+            status_label = new_status
+
         fields = [
-            {"name": "Coverage", "value": result.seadex_status.capitalize(), "inline": True},
-            {"name": "Current", "value": ", ".join(result.library_rgs) or "None", "inline": True},
-            {"name": "SeaDex", "value": ", ".join(result.seadex_rgs) or "None", "inline": True},
+            {"name": "Coverage", "value": status_label, "inline": True},
+            {
+                "name": "Library",
+                "value": ", ".join(result.library_rgs) or "None",
+                "inline": True,
+            },
+            {
+                "name": "SeaDex",
+                "value": ", ".join(result.seadex_rgs) or "None",
+                "inline": True,
+            },
         ]
+
+        # Release-group diff field — only when something actually changed
+        if added_rgs or removed_rgs:
+            diff_parts = [f"+{rg}" for rg in added_rgs] + [f"-{rg}" for rg in removed_rgs]
+            fields.append({
+                "name": "Changes",
+                "value": "  ".join(diff_parts),
+                "inline": False,
+            })
 
         if result.upgrade_available:
             size_str = f"{sd_gb:.1f} GB ({delta_gb:+.1f} GB vs current)"
@@ -428,12 +529,17 @@ class SeaDexAudit(SeaDexSonarr):
             },
             "title": result.anilist_title or result.sonarr_title,
             "description": result.sd_url or "",
+            "color": self._embed_colour(result),
             "fields": fields,
             "thumbnail": {"url": anilist_thumb},
         }])
         time.sleep(1)
 
-    def _send_batch_discord(self, results: list[AuditResult]):
+    def _send_batch_discord(
+        self,
+        results: list[AuditResult],
+        old_states: dict[int, Optional[SeriesAuditState]],
+    ):
         if not self.discord_url or not results:
             return
 
@@ -446,11 +552,17 @@ class SeaDexAudit(SeaDexSonarr):
                 lib_gb = r.library_size_bytes / BYTES_PER_GB
                 delta_gb = sd_gb - lib_gb
 
+                old_s = old_states.get(r.sonarr_id)
+                added_rgs, removed_rgs = rg_diff(old_s, self._to_state(r))
+
                 parts = [f"Coverage: {r.seadex_status.capitalize()}"]
                 if r.library_rgs:
-                    parts.append(f"Current: {', '.join(r.library_rgs)}")
+                    parts.append(f"Library: {', '.join(r.library_rgs)}")
                 if r.seadex_rgs:
                     parts.append(f"SeaDex: {', '.join(r.seadex_rgs)}")
+                if added_rgs or removed_rgs:
+                    diff_parts = [f"+{rg}" for rg in added_rgs] + [f"-{rg}" for rg in removed_rgs]
+                    parts.append(f"Changes: {' '.join(diff_parts)}")
                 if r.upgrade_available:
                     flag = " ⚠ Too Large" if r.too_large else " ↑ Upgrade"
                     parts.append(f"Size: {sd_gb:.1f} GB ({delta_gb:+.1f} GB){flag}")
@@ -459,6 +571,7 @@ class SeaDexAudit(SeaDexSonarr):
                     "author": {"name": "SeaDexArr Audit"},
                     "title": r.anilist_title or r.sonarr_title,
                     "description": "\n".join(parts),
+                    "color": self._embed_colour(r),
                     "url": r.sd_url or "",
                 })
 

--- a/seadexarr/modules/audit_state.py
+++ b/seadexarr/modules/audit_state.py
@@ -1,10 +1,11 @@
 import json
 import os
-from dataclasses import dataclass, asdict, field
+import sqlite3
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 @dataclass
@@ -37,35 +38,129 @@ def state_changed(old: Optional[SeriesAuditState], new: SeriesAuditState) -> boo
     )
 
 
+def rg_diff(
+    old: Optional[SeriesAuditState], new: SeriesAuditState
+) -> tuple[list[str], list[str]]:
+    """Return (added_rgs, removed_rgs) for seadex_rgs between old and new state."""
+    old_rgs = set(old.seadex_rgs) if old else set()
+    new_rgs = set(new.seadex_rgs)
+    return sorted(new_rgs - old_rgs), sorted(old_rgs - new_rgs)
+
+
 class AuditState:
+    """SQLite-backed audit state. Accepts .json path for migration from the old backend."""
+
     def __init__(self, path: str):
-        self.path = path
-        self._data: dict = {"schema_version": SCHEMA_VERSION, "series": {}}
-        if os.path.exists(path):
-            self._load()
+        # Normalise to .db; keep old .json path for one-time migration
+        if path.endswith(".json"):
+            self._legacy_json: Optional[str] = path
+            db_path = path[:-5] + ".db"
+        else:
+            self._legacy_json = None
+            db_path = path
 
-    def _load(self):
-        with open(self.path, "r", encoding="utf-8") as f:
-            content = f.read().strip()
-        if not content:
-            return
-        self._data = json.loads(content)
+        self.path = db_path
 
-    def save(self):
-        parent = os.path.dirname(os.path.abspath(self.path))
+        parent = os.path.dirname(os.path.abspath(db_path))
         if parent:
             os.makedirs(parent, exist_ok=True)
-        with open(self.path, "w", encoding="utf-8") as f:
-            json.dump(self._data, f, indent=2)
+
+        self._conn = sqlite3.connect(db_path)
+        self._init_schema()
+
+        if self._legacy_json and os.path.exists(self._legacy_json):
+            self._migrate_from_json(self._legacy_json)
+
+    # ------------------------------------------------------------------
+    # Schema / migration
+    # ------------------------------------------------------------------
+
+    def _init_schema(self):
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS series (
+                sonarr_id        INTEGER PRIMARY KEY,
+                tvdb_id          INTEGER,
+                title            TEXT    NOT NULL,
+                seadex_status    TEXT    NOT NULL,
+                seadex_rgs       TEXT    NOT NULL DEFAULT '[]',
+                seadex_size_bytes INTEGER NOT NULL DEFAULT 0,
+                library_rgs      TEXT    NOT NULL DEFAULT '[]',
+                upgrade_available INTEGER NOT NULL DEFAULT 0,
+                too_large        INTEGER NOT NULL DEFAULT 0,
+                last_notified    TEXT,
+                last_audited     TEXT    NOT NULL DEFAULT ''
+            )
+        """)
+        self._conn.commit()
+
+    def _migrate_from_json(self, json_path: str):
+        try:
+            with open(json_path, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+            if not content:
+                return
+            data = json.loads(content)
+            for entry in data.get("series", {}).values():
+                self._upsert_row(SeriesAuditState(**entry))
+            self._conn.commit()
+            os.rename(json_path, json_path + ".migrated")
+        except Exception:
+            pass  # migration failure must not block startup
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _upsert_row(self, state: SeriesAuditState):
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO series
+                (sonarr_id, tvdb_id, title, seadex_status, seadex_rgs,
+                 seadex_size_bytes, library_rgs, upgrade_available, too_large,
+                 last_notified, last_audited)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                state.sonarr_id,
+                state.tvdb_id,
+                state.title,
+                state.seadex_status,
+                json.dumps(state.seadex_rgs),
+                state.seadex_size_bytes,
+                json.dumps(state.library_rgs),
+                int(state.upgrade_available),
+                int(state.too_large),
+                state.last_notified,
+                state.last_audited,
+            ),
+        )
+
+    def _row_to_state(self, row: tuple) -> SeriesAuditState:
+        return SeriesAuditState(
+            sonarr_id=row[0],
+            tvdb_id=row[1],
+            title=row[2],
+            seadex_status=row[3],
+            seadex_rgs=json.loads(row[4]),
+            seadex_size_bytes=row[5],
+            library_rgs=json.loads(row[6]),
+            upgrade_available=bool(row[7]),
+            too_large=bool(row[8]),
+            last_notified=row[9],
+            last_audited=row[10],
+        )
+
+    # ------------------------------------------------------------------
+    # Public API (same surface as the old JSON-backed class)
+    # ------------------------------------------------------------------
 
     def get_series(self, sonarr_id: int) -> Optional[SeriesAuditState]:
-        raw = self._data.get("series", {}).get(str(sonarr_id))
-        if raw is None:
-            return None
-        return SeriesAuditState(**raw)
+        row = self._conn.execute(
+            "SELECT * FROM series WHERE sonarr_id = ?", (sonarr_id,)
+        ).fetchone()
+        return self._row_to_state(row) if row is not None else None
 
     def should_notify(self, new_state: SeriesAuditState, discord_cfg: dict) -> bool:
-        """True when this state warrants a Discord notification."""
         old = self.get_series(new_state.sonarr_id)
 
         if not state_changed(old, new_state):
@@ -87,7 +182,6 @@ class AuditState:
         if newly_large:
             return discord_cfg.get("notify_on_too_large", True)
 
-        # Generic state change (status flip, rg change, etc.)
         return True
 
     def update_series(self, state: SeriesAuditState, notified: bool = False):
@@ -95,4 +189,17 @@ class AuditState:
         state.last_audited = now
         if notified:
             state.last_notified = now
-        self._data.setdefault("series", {})[state.state_key()] = asdict(state)
+        self._upsert_row(state)
+        self._conn.commit()
+
+    def save(self):
+        """No-op: SQLite writes are committed immediately in update_series."""
+
+    def close(self):
+        self._conn.close()
+
+    def __del__(self):
+        try:
+            self._conn.close()
+        except Exception:
+            pass

--- a/seadexarr/modules/audit_state.py
+++ b/seadexarr/modules/audit_state.py
@@ -1,0 +1,98 @@
+import json
+import os
+from dataclasses import dataclass, asdict, field
+from datetime import datetime, timezone
+from typing import Optional
+
+SCHEMA_VERSION = 1
+
+
+@dataclass
+class SeriesAuditState:
+    sonarr_id: int
+    tvdb_id: Optional[int]
+    title: str
+    seadex_status: str          # none / partial / full
+    seadex_rgs: list[str] = field(default_factory=list)
+    seadex_size_bytes: int = 0
+    library_rgs: list[str] = field(default_factory=list)
+    upgrade_available: bool = False
+    too_large: bool = False
+    last_notified: Optional[str] = None
+    last_audited: str = ""
+
+    def state_key(self) -> str:
+        return str(self.sonarr_id)
+
+
+def state_changed(old: Optional[SeriesAuditState], new: SeriesAuditState) -> bool:
+    if old is None:
+        return True
+    return (
+        old.seadex_status != new.seadex_status
+        or set(old.seadex_rgs) != set(new.seadex_rgs)
+        or set(old.library_rgs) != set(new.library_rgs)
+        or old.upgrade_available != new.upgrade_available
+        or old.too_large != new.too_large
+    )
+
+
+class AuditState:
+    def __init__(self, path: str):
+        self.path = path
+        self._data: dict = {"schema_version": SCHEMA_VERSION, "series": {}}
+        if os.path.exists(path):
+            self._load()
+
+    def _load(self):
+        with open(self.path, "r", encoding="utf-8") as f:
+            content = f.read().strip()
+        if not content:
+            return
+        self._data = json.loads(content)
+
+    def save(self):
+        parent = os.path.dirname(os.path.abspath(self.path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(self._data, f, indent=2)
+
+    def get_series(self, sonarr_id: int) -> Optional[SeriesAuditState]:
+        raw = self._data.get("series", {}).get(str(sonarr_id))
+        if raw is None:
+            return None
+        return SeriesAuditState(**raw)
+
+    def should_notify(self, new_state: SeriesAuditState, discord_cfg: dict) -> bool:
+        """True when this state warrants a Discord notification."""
+        old = self.get_series(new_state.sonarr_id)
+
+        if not state_changed(old, new_state):
+            return discord_cfg.get("notify_on_no_change", False)
+
+        was_none = old is None or old.seadex_status == "none"
+
+        if new_state.seadex_status == "partial" and was_none:
+            return discord_cfg.get("notify_on_partial_match", True)
+
+        if new_state.seadex_status == "full" and was_none:
+            return discord_cfg.get("notify_on_new_seadex_match", True)
+
+        newly_upgrade = new_state.upgrade_available and (old is None or not old.upgrade_available)
+        if newly_upgrade:
+            return discord_cfg.get("notify_on_new_upgrade_available", True)
+
+        newly_large = new_state.too_large and (old is None or not old.too_large)
+        if newly_large:
+            return discord_cfg.get("notify_on_too_large", True)
+
+        # Generic state change (status flip, rg change, etc.)
+        return True
+
+    def update_series(self, state: SeriesAuditState, notified: bool = False):
+        now = datetime.now(timezone.utc).isoformat()
+        state.last_audited = now
+        if notified:
+            state.last_notified = now
+        self._data.setdefault("series", {})[state.state_key()] = asdict(state)

--- a/seadexarr/modules/audit_state.py
+++ b/seadexarr/modules/audit_state.py
@@ -94,18 +94,37 @@ class AuditState:
         self._conn.commit()
 
     def _migrate_from_json(self, json_path: str):
+        import logging as _logging
+        _log = _logging.getLogger(__name__)
         try:
             with open(json_path, "r", encoding="utf-8") as f:
                 content = f.read().strip()
             if not content:
+                os.rename(json_path, json_path + ".migrated")
                 return
             data = json.loads(content)
-            for entry in data.get("series", {}).values():
+        except Exception as exc:
+            _log.warning("audit_state: could not read legacy JSON %s: %s — starting fresh", json_path, exc)
+            return
+
+        migrated = failed = 0
+        for key, entry in data.get("series", {}).items():
+            try:
                 self._upsert_row(SeriesAuditState(**entry))
-            self._conn.commit()
+                migrated += 1
+            except Exception as exc:
+                failed += 1
+                _log.warning("audit_state: skipping entry %s during migration: %s", key, exc)
+
+        self._conn.commit()
+        if failed == 0:
             os.rename(json_path, json_path + ".migrated")
-        except Exception:
-            pass  # migration failure must not block startup
+            _log.info("audit_state: migrated %d entries from JSON (renamed to .migrated)", migrated)
+        else:
+            _log.warning(
+                "audit_state: migrated %d entries; %d failed — JSON preserved at %s",
+                migrated, failed, json_path,
+            )
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -182,7 +201,8 @@ class AuditState:
         if newly_large:
             return discord_cfg.get("notify_on_too_large", True)
 
-        return True
+        # State changed but no specific rule matched (e.g. partial→full when already seen)
+        return discord_cfg.get("notify_on_state_change", True)
 
     def update_series(self, state: SeriesAuditState, notified: bool = False):
         now = datetime.now(timezone.utc).isoformat()

--- a/seadexarr/modules/cli.py
+++ b/seadexarr/modules/cli.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import shutil
+import sys
 import time
 import traceback
 from datetime import datetime, timedelta
@@ -11,6 +12,15 @@ from .audit import SeaDexAudit
 from .seadex_arr import setup_logger
 from .seadex_radarr import SeaDexRadarr
 from .seadex_sonarr import SeaDexSonarr
+
+def _make_logger():
+    try:
+        return setup_logger(log_level=os.getenv("LOG_LEVEL", "INFO"))
+    except Exception as exc:
+        print(f"[SeaDexArr] FATAL: could not create log file: {exc}", file=sys.stderr)
+        print(f"[SeaDexArr] Check that CONFIG_DIR ({os.getenv('CONFIG_DIR', '/config')}) is mounted and writable.", file=sys.stderr)
+        raise
+
 
 seadexarr_cli = typer.Typer(name="seadexarr_cli")
 seadexarr_run = typer.Typer(name="run")
@@ -56,7 +66,7 @@ def run_scheduled():
 
     while True:
 
-        logger = setup_logger(log_level="INFO")
+        logger = _make_logger()
         logger.info(f"Running in scheduled mode")
 
         present_time = datetime.now().strftime("%H:%M")
@@ -115,7 +125,8 @@ def run_single(
     config = os.path.join(config_dir, "config.yml")
     cache = os.path.join(config_dir, "cache.json")
 
-    logger = setup_logger(log_level="INFO")
+    logger = _make_logger()
+    logger.info("Starting single run")
 
     if radarr:
         try:
@@ -175,7 +186,8 @@ def run_audit(
     config = os.path.join(config_dir, "config.yml")
     cache = os.path.join(config_dir, "cache.json")
 
-    logger = setup_logger(log_level="INFO")
+    logger = _make_logger()
+    logger.info("Starting audit run")
 
     try:
         sda = SeaDexAudit(config=config, cache=cache, logger=logger)

--- a/seadexarr/modules/cli.py
+++ b/seadexarr/modules/cli.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 
 import typer
 
+from .audit import SeaDexAudit
 from .seadex_arr import setup_logger
 from .seadex_radarr import SeaDexRadarr
 from .seadex_sonarr import SeaDexSonarr
@@ -15,10 +16,12 @@ seadexarr_cli = typer.Typer(name="seadexarr_cli")
 seadexarr_run = typer.Typer(name="run")
 seadexarr_config = typer.Typer(name="config")
 seadexarr_cache = typer.Typer(name="cache")
+seadexarr_audit = typer.Typer(name="audit")
 
 seadexarr_cli.add_typer(seadexarr_run)
 seadexarr_cli.add_typer(seadexarr_config)
 seadexarr_cli.add_typer(seadexarr_cache)
+seadexarr_cli.add_typer(seadexarr_audit)
 
 
 # Default command, schedule run
@@ -139,6 +142,48 @@ def run_single(
             tb = traceback.format_exc()
             for line in tb.splitlines():
                 logger.warning(line)
+
+    return True
+
+
+# Audit commands
+@seadexarr_audit.callback(invoke_without_command=True)
+def run_audit(
+    ctx: typer.Context,
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Log intended tag changes without applying them (no Sonarr mutations)",
+    ),
+    apply_tags: bool = typer.Option(
+        False,
+        "--apply-tags",
+        help="Apply SeaDex Sonarr tags; still never downloads",
+    ),
+    notify_only: bool = typer.Option(
+        False,
+        "--notify-only",
+        help="Send Discord notifications only; skip tag updates",
+    ),
+):
+    """Audit Sonarr library against SeaDex. Tags series; never grabs torrents."""
+
+    if ctx.invoked_subcommand is not None:
+        return True
+
+    config_dir = os.getenv("CONFIG_DIR", os.getcwd())
+    config = os.path.join(config_dir, "config.yml")
+    cache = os.path.join(config_dir, "cache.json")
+
+    logger = setup_logger(log_level="INFO")
+
+    try:
+        sda = SeaDexAudit(config=config, cache=cache, logger=logger)
+        sda.run(dry_run=dry_run, apply_tags=apply_tags, notify_only=notify_only)
+    except Exception:
+        tb = traceback.format_exc()
+        for line in tb.splitlines():
+            logger.warning(line)
 
     return True
 

--- a/seadexarr/modules/config_sample.yml
+++ b/seadexarr/modules/config_sample.yml
@@ -47,3 +47,38 @@ anime_mappings:
 anidb_mappings:
 anibridge_mappings:
 log_level: "INFO"
+
+# Audit mode: scan, classify, tag — never grabs torrents
+audit:
+  enabled: false
+  dry_run: true           # true = log only, no Sonarr mutations
+  sonarr_only: true
+  notify_discord: true
+  update_sonarr_tags: true
+  remove_stale_tags: false  # only removes tags listed in audit.tags
+
+  tags:
+    full_seadex: seadex
+    partial_seadex: partial-seadex
+    upgrade_available: seadex-upgrade-available
+    too_large: seadex-too-large
+    ignored: seadex-ignored
+
+  size_filters:
+    enabled: true
+    max_absolute_gb: 80
+    max_size_multiplier: 2.0
+    notify_when_too_large: true
+    tag_when_too_large: true
+
+  discord:
+    notify_on_new_seadex_match: true
+    notify_on_new_upgrade_available: true
+    notify_on_partial_match: true
+    notify_on_too_large: true
+    notify_on_no_change: false
+    batch_notifications: true
+
+  state:
+    enabled: true
+    path:    # defaults to /config/audit_state.json if blank

--- a/seadexarr/modules/config_sample.yml
+++ b/seadexarr/modules/config_sample.yml
@@ -64,6 +64,11 @@ audit:
     too_large: seadex-too-large
     ignored: seadex-ignored
 
+  # If true, having any SeaDex-listed release (best OR alt) is considered
+  # acceptable — series won't be flagged for upgrade just because a "best"
+  # release exists when you already have an "alt" one.
+  alt_is_acceptable: false
+
   size_filters:
     enabled: true
     max_absolute_gb: 80

--- a/seadexarr/modules/log.py
+++ b/seadexarr/modules/log.py
@@ -31,7 +31,7 @@ def setup_logger(
     """
 
     if os.environ.get("DOCKER_ENV"):
-        config_dir = os.environ.get("CONFIG_DIR")
+        config_dir = os.environ.get("CONFIG_DIR", "/config")
         log_dir = os.path.join(config_dir, log_dir)
     else:
         log_dir = os.path.join(os.getcwd(), log_dir)
@@ -63,17 +63,13 @@ def setup_logger(
 
     # Set the log level based on the provided parameter
     log_level = log_level.upper()
-    if log_level == "DEBUG":
-        logger.setLevel(logging.DEBUG)
-    elif log_level == "INFO":
-        logger.setLevel(logging.INFO)
-    elif log_level == "WARNING":
-        logger.setLevel(logging.WARNING)
-    elif log_level == "CRITICAL":
-        logger.setLevel(logging.CRITICAL)
-    else:
-        logger.critical(f"Invalid log level '{log_level}', defaulting to 'INFO'")
-        logger.setLevel(logging.INFO)
+    level_map = {
+        "DEBUG": logging.DEBUG,
+        "INFO": logging.INFO,
+        "WARNING": logging.WARNING,
+        "CRITICAL": logging.CRITICAL,
+    }
+    numeric_level = level_map.get(log_level)
 
     # Define the log message format for the log files
     logfile_formatter = logging.Formatter(
@@ -82,32 +78,28 @@ def setup_logger(
 
     # Create a RotatingFileHandler for log files
     handler = RotatingFileHandler(
-        log_file, delay=True, mode="w", encoding="utf-8", backupCount=max_logs
+        log_file, mode="w", encoding="utf-8", backupCount=max_logs
     )
     handler.setFormatter(logfile_formatter)
 
-    # Add the file handler to the logger
-    logger.addHandler(handler)
-
-    # Configure console logging with the specified log level
+    # Configure console logging
     console_handler = colorlog.StreamHandler(sys.stdout)
-    if log_level == "DEBUG":
-        console_handler.setLevel(logging.DEBUG)
-    elif log_level == "INFO":
-        console_handler.setLevel(logging.INFO)
-    elif log_level == "CRITICAL":
-        console_handler.setLevel(logging.CRITICAL)
-
-    # Add the console handler to the logger
     console_handler.setFormatter(
         colorlog.ColoredFormatter("%(log_color)s%(levelname)s: %(message)s")
     )
+
+    # Replace any handlers from a previous setup_logger call
+    logger.handlers.clear()
+    logger.addHandler(handler)
     logger.addHandler(console_handler)
 
-    # Overwrite previous logger if exists
-    logging.getLogger(log_name).handlers.clear()
-    logging.getLogger(log_name).addHandler(handler)
-    logging.getLogger(log_name).addHandler(console_handler)
+    if numeric_level is None:
+        logger.setLevel(logging.INFO)
+        logger.critical(f"Invalid log level '{log_level}', defaulting to 'INFO'")
+    else:
+        logger.setLevel(numeric_level)
+        handler.setLevel(numeric_level)
+        console_handler.setLevel(numeric_level)
 
     return logger
 

--- a/seadexarr/modules/log.py
+++ b/seadexarr/modules/log.py
@@ -37,8 +37,9 @@ def setup_logger(
         log_dir = os.path.join(os.getcwd(), log_dir)
 
     # Create the log directory if it doesn't exist
+    # mode=0o755 ensures the directory is traversable via SMB/NFS
     if not os.path.exists(log_dir):
-        os.makedirs(log_dir)
+        os.makedirs(log_dir, mode=0o755)
 
     # Define the log file path
     log_file = os.path.join(log_dir, f"{log_name}.log")

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -242,6 +242,8 @@ class SeaDexArr:
 
         self.trackers = [t.lower() for t in trackers]
 
+        self.audit_mode = False
+
         # Advanced settings
         self.sleep_time = self.config.get("sleep_time", 2)
         self.cache_time = self.config.get("cache_time", 1)
@@ -783,6 +785,20 @@ class SeaDexArr:
 
         return seadex_release_groups
 
+    @staticmethod
+    def _fmt_size_gb(size_list):
+        """Sum a list of byte sizes and return a human-readable GB string, or '' if unknown."""
+        if not size_list:
+            return ""
+        valid = [s for s in size_list if s is not None]
+        if not valid:
+            return ""
+        return f"{sum(valid) / 1e9:.2f} GB"
+
+    def _action_word(self):
+        """Return 'tagging' in audit mode, 'downloading' otherwise."""
+        return "tagging" if self.audit_mode else "downloading"
+
     def filter_seadex_interactive(
         self,
         seadex_dict,
@@ -870,6 +886,7 @@ class SeaDexArr:
         al_id,
         release_group,
         seadex_dict,
+        arr_release_dict=None,
     ):
         """Get fields for Discord post
 
@@ -878,6 +895,7 @@ class SeaDexArr:
             al_id: AniList ID
             release_group: Arr release group
             seadex_dict: Dictionary of SeaDex releases
+            arr_release_dict: Dictionary of arr release properties (optional, for size info)
         """
 
         anilist_thumb, self.al_cache = get_anilist_thumb(
@@ -885,6 +903,8 @@ class SeaDexArr:
             al_cache=self.al_cache,
         )
         fields = []
+
+        action = "Tagging" if self.audit_mode else "Downloading"
 
         # The first field should be the Arr group. If it's empty, mention it's missing
         release_group_discord = copy.deepcopy(release_group)
@@ -897,9 +917,16 @@ class SeaDexArr:
         if isinstance(release_group_discord, str):
             release_group_discord = [release_group]
 
+        # Build current release field with size info if available
+        have_lines = []
+        for rg in release_group_discord:
+            rg_sizes = (arr_release_dict or {}).get(rg, {}).get("size", []) if arr_release_dict else []
+            size_str = self._fmt_size_gb(rg_sizes)
+            have_lines.append(f"{rg}" + (f" ({size_str})" if size_str else ""))
+
         field_dict = {
-            "name": f"{arr.capitalize()} Release:",
-            "value": "\n".join(release_group_discord),
+            "name": f"{arr.capitalize()} Release (current):",
+            "value": "\n".join(have_lines),
         }
         fields.append(field_dict)
 
@@ -914,23 +941,34 @@ class SeaDexArr:
 
             if any(dl):
 
-                # Include any tags in the string
                 discord_value = ""
+
+                # Tags
                 tags = srg_item.get("tags", [])
                 if len(tags) > 0:
-                    discord_value += "Tags:\n"
-                    discord_value += "\n".join(tags)
-                    discord_value += "\n\n"
+                    discord_value += "Tags: " + ", ".join(tags) + "\n"
+
+                # Total size across all URLs being downloaded
+                all_dl_sizes = [
+                    s
+                    for url, url_item in (srg_item.get("urls") or {}).items()
+                    if (url_item or {}).get("download", False)
+                    for s in ((url_item or {}).get("size") or [])
+                ]
+                size_str = self._fmt_size_gb(all_dl_sizes)
+                if size_str:
+                    discord_value += f"Size: {size_str}\n"
+
+                discord_value += "\n"
 
                 urls_to_download = [x for i, x in enumerate(srg_item["urls"]) if dl[i]]
 
-                # And include URLs for files we're downloading
                 discord_value += "Links:\n"
                 discord_value += "\n".join(urls_to_download)
 
                 field_dict = {
-                    "name": f"SeaDex recommendation: {srg}",
-                    "value": f"{discord_value}",
+                    "name": f"{action}: {srg}",
+                    "value": discord_value,
                 }
 
                 fields.append(field_dict)
@@ -1108,11 +1146,21 @@ class SeaDexArr:
                 # just fall back to checking against release group
                 if len(seadex_episodes) == 0:
                     if seadex_rg not in arr_release_groups and not overlapping_results:
-                        self.logger.debug(
+                        have_str = ", ".join(arr_release_groups) if arr_release_groups else "nothing"
+                        have_sizes = [
+                            s
+                            for rg in arr_release_groups
+                            for s in (arr_release_dict.get(rg, {}).get("size") or [])
+                        ]
+                        have_size_str = self._fmt_size_gb(have_sizes)
+                        sd_size_str = self._fmt_size_gb(url_item.get("size", []))
+                        sd_tags = seadex_rg_item.get("tags", [])
+                        sd_tag_str = f" ({', '.join(sd_tags)})" if sd_tags else ""
+                        have_part = f"[{have_str}]" + (f" ({have_size_str})" if have_size_str else "")
+                        sd_part = f"[{seadex_rg}]" + (f" ({sd_size_str})" if sd_size_str else "") + sd_tag_str
+                        self.logger.info(
                             left_aligned_string(
-                                f"SeaDex release group {seadex_rg} not in {arr.capitalize()} release(s): "
-                                f"{','.join([str(x) for x in arr_release_groups])}. "
-                                f"Will add {url} to downloads",
+                                f"Have: {have_part} | SeaDex: {sd_part} → {self._action_word()}",
                                 total_length=self.log_line_length,
                             )
                         )
@@ -1137,13 +1185,18 @@ class SeaDexArr:
                             )
                         )
 
+                        sd_tags = seadex_rg_item.get("tags", [])
+                        sd_tag_str = f" ({', '.join(sd_tags)})" if sd_tags else ""
+                        arr_size_str = self._fmt_size_gb(arr_file_sizes)
+                        sd_size_str = self._fmt_size_gb(seadex_file_sizes)
+
                         # If we have no overlaps at all, then add
                         if len(intersect) == 0:
+                            have_part = f"[{seadex_rg}]" + (f" ({arr_size_str})" if arr_size_str else "")
+                            sd_part = f"[{seadex_rg}]" + (f" ({sd_size_str})" if sd_size_str else "") + sd_tag_str
                             self.logger.info(
                                 left_aligned_string(
-                                    f"SeaDex release group {seadex_rg} in {arr.capitalize()} release(s): "
-                                    f"{','.join([str(x) for x in arr_release_groups])}, but filesizes do not match. "
-                                    f"Will add {url} to downloads",
+                                    f"Have: {have_part} | SeaDex: {sd_part} (size differs) → {self._action_word()}",
                                     total_length=self.log_line_length,
                                 )
                             )
@@ -1152,10 +1205,11 @@ class SeaDexArr:
                             torrent_hashes.append(url_hash)
 
                         else:
-                            self.logger.debug(
+                            have_part = f"[{seadex_rg}]" + (f" ({arr_size_str})" if arr_size_str else "")
+                            sd_part = f"[{seadex_rg}]" + (f" ({sd_size_str})" if sd_size_str else "") + sd_tag_str
+                            self.logger.info(
                                 left_aligned_string(
-                                    f"SeaDex release group {seadex_rg} in {arr.capitalize()} release(s): "
-                                    f"{','.join([str(x) for x in arr_release_groups])}, and filesizes match. ",
+                                    f"Have: {have_part} | SeaDex: {sd_part} → already have it ✓",
                                     total_length=self.log_line_length,
                                 )
                             )
@@ -1229,13 +1283,14 @@ class SeaDexArr:
                                     )
 
                                     if sonarr_rg not in all_seadex_rg:
-                                        self.logger.debug(
+                                        sd_tags = seadex_rg_item.get("tags", [])
+                                        sd_tag_str = f" ({', '.join(sd_tags)})" if sd_tags else ""
+                                        sd_ep_size_str = self._fmt_size_gb([seadex_ep_size])
+                                        have_part = f"[{sonarr_rg}] {season_ep_str}"
+                                        sd_part = f"[{seadex_rg}] {season_ep_str}" + (f" ({sd_ep_size_str})" if sd_ep_size_str else "") + sd_tag_str
+                                        self.logger.info(
                                             left_aligned_string(
-                                                f"SeaDex release group {seadex_rg} not the same as "
-                                                f"{arr.capitalize()} release for "
-                                                f"{season_ep_str} {sonarr_rg}, "
-                                                f"and does not match any other suitable releases. "
-                                                f"Will add {url} to downloads",
+                                                f"Have: {have_part} | SeaDex: {sd_part} → {self._action_word()}",
                                                 total_length=self.log_line_length,
                                             )
                                         )
@@ -1280,10 +1335,16 @@ class SeaDexArr:
                     # here and mark for download
                     size_matches = list(compress(size_matches, rg_matches))
                     if not any(size_matches) and len(size_matches) > 0:
+                        sd_tags = seadex_rg_item.get("tags", [])
+                        sd_tag_str = f" ({', '.join(sd_tags)})" if sd_tags else ""
+                        sd_size_str = self._fmt_size_gb(url_item.get("size", []))
+                        arr_sizes = arr_release_dict.get(seadex_rg, {}).get("size", [])
+                        arr_size_str = self._fmt_size_gb(arr_sizes)
+                        have_part = f"[{seadex_rg}]" + (f" ({arr_size_str})" if arr_size_str else "")
+                        sd_part = f"[{seadex_rg}]" + (f" ({sd_size_str})" if sd_size_str else "") + sd_tag_str
                         self.logger.info(
                             left_aligned_string(
-                                f"File sizes are all different for release group {seadex_rg}. "
-                                f"Will add {url} to downloads",
+                                f"Have: {have_part} | SeaDex: {sd_part} (episode sizes differ) → {self._action_word()}",
                                 total_length=self.log_line_length,
                             )
                         )
@@ -1763,6 +1824,8 @@ class SeaDexArr:
             "sonarr": "series",
         }[arr]
 
+        action = self._action_word().capitalize()
+
         self.logger.info(
             centred_string(
                 f"Mismatch found between SeaDex recommendation and existing {arr.capitalize()} {item_type}!",
@@ -1771,7 +1834,7 @@ class SeaDexArr:
         )
         self.logger.info(
             centred_string(
-                f"SeaDex recommended version(s):",
+                f"SeaDex recommended version(s) ({action}):",
                 total_length=self.log_line_length,
             )
         )
@@ -1784,20 +1847,23 @@ class SeaDexArr:
                 for x in (srg_item.get("urls") or {})
             ]
             if any(dl):
+                # Compute total size for this release group
+                all_sizes = [
+                    s
+                    for url, url_item in (srg_item.get("urls") or {}).items()
+                    if (url_item or {}).get("download", False)
+                    for s in ((url_item or {}).get("size") or [])
+                ]
+                size_str = self._fmt_size_gb(all_sizes)
+                tags = srg_item.get("tags", [])
+                tag_str = f" [{', '.join(tags)}]" if tags else ""
+                size_part = f" ({size_str})" if size_str else ""
                 self.logger.info(
                     left_aligned_string(
-                        f"{srg}:",
+                        f"{srg}{size_part}{tag_str}:",
                         total_length=self.log_line_length,
                     )
                 )
-                tags = srg_item.get("tags", [])
-                if len(tags) > 0:
-                    self.logger.info(
-                        left_aligned_string(
-                            f"   Tags: {','.join([t for t in tags])}",
-                            total_length=self.log_line_length,
-                        )
-                    )
                 for url in srg_item.get("urls", {}):
 
                     download = (

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -593,10 +593,15 @@ class SeaDexArr:
                 "At least one of tvdb_id, tmdb_id, and imdb_id must be provided"
             )
 
+        # The Kometa Anime-IDs file keys each entry by its AniDB ID, so the
+        # AniDB ID lives in the dict key (n) and is *not* duplicated inside the
+        # value (m). get_ep_list needs it to look up AniDB episode mappings for
+        # specials/OVAs/movies, so fold the key into the mapping as "anidb_id".
+        # Use {"anidb_id": n, **m} so any pre-existing value in m wins.
         if tvdb_id is not None:
             anilist_mappings.update(
                 {
-                    m["anilist_id"]: m
+                    m["anilist_id"]: {"anidb_id": n, **m}
                     for n, m in self.anime_mappings.items()
                     if m.get("tvdb_id", None) == tvdb_id
                     and m.get("anilist_id", None) is not None
@@ -606,7 +611,7 @@ class SeaDexArr:
         if tmdb_id is not None:
             anilist_mappings.update(
                 {
-                    m["anilist_id"]: m
+                    m["anilist_id"]: {"anidb_id": n, **m}
                     for n, m in self.anime_mappings.items()
                     if m.get(f"tmdb_{tmdb_type}_id", None) == tmdb_id
                     and m.get("anilist_id", None) is not None
@@ -616,7 +621,7 @@ class SeaDexArr:
         if imdb_id is not None:
             anilist_mappings.update(
                 {
-                    m["anilist_id"]: m
+                    m["anilist_id"]: {"anidb_id": n, **m}
                     for n, m in self.anime_mappings.items()
                     if m.get("imdb_id", None) == imdb_id
                     and m.get("anilist_id", None) is not None

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -476,7 +476,7 @@ class SeaDexArr:
             sd_entry = self.seadex.from_id(al_id)
         except EntryNotFoundError:
             pass
-        except httpx.ConnectError:
+        except (httpx.ConnectError, httpx.ReadTimeout):
             self.logger.warning("Could not connect to SeaDex. Website may be down")
 
         return sd_entry

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -1186,7 +1186,7 @@ class SeaDexArr:
                             # Get Season, Episode, and size numbers for Sonarr and SeaDex
                             sonarr_ep_season = sonarr_ep.get("seasonNumber", 999)
                             sonarr_ep_episode = sonarr_ep.get("episodeNumber", 999)
-                            sonarr_ep_size = sonarr_ep.get("episodeFile", {}).get(
+                            sonarr_ep_size = (sonarr_ep.get("episodeFile") or {}).get(
                                 "size", None
                             )
 
@@ -1208,7 +1208,7 @@ class SeaDexArr:
                                 )
 
                                 # Check SeaDex release group matches the episode release group in Sonarr
-                                sonarr_rg = sonarr_ep.get("episodeFile", {}).get(
+                                sonarr_rg = (sonarr_ep.get("episodeFile") or {}).get(
                                     "releaseGroup", None
                                 )
 

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -1207,7 +1207,7 @@ class SeaDexArr:
                         else:
                             have_part = f"[{seadex_rg}]" + (f" ({arr_size_str})" if arr_size_str else "")
                             sd_part = f"[{seadex_rg}]" + (f" ({sd_size_str})" if sd_size_str else "") + sd_tag_str
-                            self.logger.info(
+                            self.logger.debug(
                                 left_aligned_string(
                                     f"Have: {have_part} | SeaDex: {sd_part} → already have it ✓",
                                     total_length=self.log_line_length,
@@ -1231,6 +1231,11 @@ class SeaDexArr:
                     found_episodes = [False] * len(seadex_episodes)
                     rg_matches = [False] * len(seadex_episodes)
                     size_matches = [False] * len(seadex_episodes)
+
+                    # Collect per-episode rg-mismatch data for a single summary log line
+                    ep_rg_mismatch_have_rgs: set = set()
+                    ep_rg_mismatch_sd_sizes: list = []
+                    ep_rg_mismatch_count: int = 0
 
                     for seadex_idx, seadex_ep in enumerate(seadex_episodes):
 
@@ -1283,17 +1288,20 @@ class SeaDexArr:
                                     )
 
                                     if sonarr_rg not in all_seadex_rg:
-                                        sd_tags = seadex_rg_item.get("tags", [])
-                                        sd_tag_str = f" ({', '.join(sd_tags)})" if sd_tags else ""
-                                        sd_ep_size_str = self._fmt_size_gb([seadex_ep_size])
-                                        have_part = f"[{sonarr_rg}] {season_ep_str}"
-                                        sd_part = f"[{seadex_rg}] {season_ep_str}" + (f" ({sd_ep_size_str})" if sd_ep_size_str else "") + sd_tag_str
-                                        self.logger.info(
+                                        display_rg = sonarr_rg if sonarr_rg else "unknown"
+                                        self.logger.debug(
                                             left_aligned_string(
-                                                f"Have: {have_part} | SeaDex: {sd_part} → {self._action_word()}",
+                                                f"Have: [{display_rg}] {season_ep_str} | "
+                                                f"SeaDex: [{seadex_rg}] {season_ep_str} → {self._action_word()}",
                                                 total_length=self.log_line_length,
                                             )
                                         )
+
+                                        # Accumulate for summary
+                                        ep_rg_mismatch_have_rgs.add(display_rg)
+                                        if seadex_ep_size is not None:
+                                            ep_rg_mismatch_sd_sizes.append(seadex_ep_size)
+                                        ep_rg_mismatch_count += 1
 
                                         url_item.update({"download": True})
                                         torrent_hashes.append(url_hash)
@@ -1330,6 +1338,25 @@ class SeaDexArr:
                                     size_matches[seadex_idx] = True
 
                                 found_episodes[seadex_idx] = True
+
+                    # Emit one summary line for all per-episode rg-mismatches (collapsed from N lines)
+                    if ep_rg_mismatch_count > 0:
+                        sd_tags = seadex_rg_item.get("tags", [])
+                        sd_tag_str = f" ({', '.join(sd_tags)})" if sd_tags else ""
+                        sd_total_str = self._fmt_size_gb(ep_rg_mismatch_sd_sizes)
+                        have_rgs_str = "/".join(sorted(ep_rg_mismatch_have_rgs))
+                        sd_part = (
+                            f"[{seadex_rg}]"
+                            + (f" ({sd_total_str} total)" if sd_total_str else "")
+                            + sd_tag_str
+                        )
+                        self.logger.info(
+                            left_aligned_string(
+                                f"Have: [{have_rgs_str}] ({ep_rg_mismatch_count} eps) | "
+                                f"SeaDex: {sd_part} → {self._action_word()}",
+                                total_length=self.log_line_length,
+                            )
+                        )
 
                     # If we have matched the release groups but not the file sizes, then flag that
                     # here and mark for download

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -987,6 +987,7 @@ class SeaDexArr:
         arr,
         arr_release_dict,
         ep_list=None,
+        acceptable_alt_owned=False,
     ):
         """Flip the switch on whether we're downloading this torrent or not
 
@@ -996,6 +997,10 @@ class SeaDexArr:
             arr: Type of arr instance
             arr_release_dict: Dictionary of arr release properties
             ep_list: List of episodes. Defaults to None
+            acceptable_alt_owned: True when the library already holds a
+                SeaDex-listed alt that makes this entry acceptable (audit mode
+                with alt_is_acceptable). Softens "tagging" logs to debug since
+                the entry won't actually be flagged. Defaults to False
         """
 
         if self.use_torrent_hash_to_filter:
@@ -1010,6 +1015,7 @@ class SeaDexArr:
                 arr=arr,
                 arr_release_dict=arr_release_dict,
                 ep_list=ep_list,
+                acceptable_alt_owned=acceptable_alt_owned,
             )
 
             # Also include any cached hashes
@@ -1094,6 +1100,7 @@ class SeaDexArr:
         arr,
         arr_release_dict,
         ep_list=None,
+        acceptable_alt_owned=False,
     ):
         """Filter torrents by release group
 
@@ -1107,7 +1114,20 @@ class SeaDexArr:
             arr: Type of arr instance
             arr_release_dict: Dictionary of arr release properties
             ep_list: List of episodes. Defaults to None
+            acceptable_alt_owned: True when the library already holds a
+                SeaDex-listed alt that makes this entry acceptable. The
+                per-release "tagging" lines are then logged at debug instead
+                of info, since the caller won't actually flag the entry.
+                Defaults to False
         """
+
+        # When an owned alt already makes this acceptable, the entry won't be
+        # tagged — so demote the per-release "tagging" lines to debug and say so
+        # rather than printing a misleading "→ tagging".
+        upgrade_log = self.logger.debug if acceptable_alt_owned else self.logger.info
+        upgrade_verb = (
+            "have acceptable alt ✓" if acceptable_alt_owned else self._action_word()
+        )
 
         # Get a simple list of the release groups
         arr_release_groups = list(arr_release_dict.keys())
@@ -1163,9 +1183,9 @@ class SeaDexArr:
                         sd_tag_str = f" ({', '.join(sd_tags)})" if sd_tags else ""
                         have_part = f"[{have_str}]" + (f" ({have_size_str})" if have_size_str else "")
                         sd_part = f"[{seadex_rg}]" + (f" ({sd_size_str})" if sd_size_str else "") + sd_tag_str
-                        self.logger.info(
+                        upgrade_log(
                             left_aligned_string(
-                                f"Have: {have_part} | SeaDex: {sd_part} → {self._action_word()}",
+                                f"Have: {have_part} | SeaDex: {sd_part} → {upgrade_verb}",
                                 total_length=self.log_line_length,
                             )
                         )
@@ -1199,9 +1219,9 @@ class SeaDexArr:
                         if len(intersect) == 0:
                             have_part = f"[{seadex_rg}]" + (f" ({arr_size_str})" if arr_size_str else "")
                             sd_part = f"[{seadex_rg}]" + (f" ({sd_size_str})" if sd_size_str else "") + sd_tag_str
-                            self.logger.info(
+                            upgrade_log(
                                 left_aligned_string(
-                                    f"Have: {have_part} | SeaDex: {sd_part} (size differs) → {self._action_word()}",
+                                    f"Have: {have_part} | SeaDex: {sd_part} (size differs) → {upgrade_verb}",
                                     total_length=self.log_line_length,
                                 )
                             )
@@ -1355,10 +1375,10 @@ class SeaDexArr:
                             + (f" ({sd_total_str} total)" if sd_total_str else "")
                             + sd_tag_str
                         )
-                        self.logger.info(
+                        upgrade_log(
                             left_aligned_string(
                                 f"Have: [{have_rgs_str}] ({ep_rg_mismatch_count} eps) | "
-                                f"SeaDex: {sd_part} → {self._action_word()}",
+                                f"SeaDex: {sd_part} → {upgrade_verb}",
                                 total_length=self.log_line_length,
                             )
                         )
@@ -1374,9 +1394,9 @@ class SeaDexArr:
                         arr_size_str = self._fmt_size_gb(arr_sizes)
                         have_part = f"[{seadex_rg}]" + (f" ({arr_size_str})" if arr_size_str else "")
                         sd_part = f"[{seadex_rg}]" + (f" ({sd_size_str})" if sd_size_str else "") + sd_tag_str
-                        self.logger.info(
+                        upgrade_log(
                             left_aligned_string(
-                                f"Have: {have_part} | SeaDex: {sd_part} (episode sizes differ) → {self._action_word()}",
+                                f"Have: {have_part} | SeaDex: {sd_part} (episode sizes differ) → {upgrade_verb}",
                                 total_length=self.log_line_length,
                             )
                         )

--- a/seadexarr/modules/seadex_arr.py
+++ b/seadexarr/modules/seadex_arr.py
@@ -381,12 +381,16 @@ class SeaDexArr:
 
         return True
 
+    def _mappings_dir(self):
+        if os.environ.get("DOCKER_ENV"):
+            return os.environ.get("CONFIG_DIR", "/config")
+        return os.getcwd()
+
     def get_anime_mappings(self):
         """Get the anime IDs file"""
 
-        anime_mappings_file = os.path.join("anime_ids.json")
+        anime_mappings_file = os.path.join(self._mappings_dir(), "anime_ids.json")
 
-        # If a file doesn't exist, get it
         self.get_external_mappings(
             f=anime_mappings_file,
             url=ANIME_IDS_URL,
@@ -400,9 +404,8 @@ class SeaDexArr:
     def get_anidb_mappings(self):
         """Get the AniDB mappings file"""
 
-        anidb_mappings_file = os.path.join("anime-list-master.xml")
+        anidb_mappings_file = os.path.join(self._mappings_dir(), "anime-list-master.xml")
 
-        # If a file doesn't exist, get it
         self.get_external_mappings(
             f=anidb_mappings_file,
             url=ANIDB_MAPPINGS_URL,
@@ -415,9 +418,8 @@ class SeaDexArr:
     def get_anibridge_mappings(self):
         """Get PlexAniBridge mappings file"""
 
-        anibridge_mappings_file = os.path.join("anibridge_mappings.json")
+        anibridge_mappings_file = os.path.join(self._mappings_dir(), "anibridge_mappings.json")
 
-        # If a file doesn't exist, get it
         self.get_external_mappings(
             f=anibridge_mappings_file,
             url=ANIBRIDGE_MAPPINGS_URL,
@@ -906,8 +908,8 @@ class SeaDexArr:
 
             # Check if we're actually downloading anything
             dl = [
-                srg_item.get("urls", {}).get(x, {}).get("download", False)
-                for x in srg_item["urls"]
+                ((srg_item.get("urls") or {}).get(x) or {}).get("download", False)
+                for x in (srg_item.get("urls") or {})
             ]
 
             if any(dl):
@@ -1778,8 +1780,8 @@ class SeaDexArr:
         for srg, srg_item in seadex_dict.items():
 
             dl = [
-                srg_item.get("urls", {}).get(x, {}).get("download", False)
-                for x in srg_item.get("urls", {})
+                ((srg_item.get("urls") or {}).get(x) or {}).get("download", False)
+                for x in (srg_item.get("urls") or {})
             ]
             if any(dl):
                 self.logger.info(
@@ -1799,7 +1801,7 @@ class SeaDexArr:
                 for url in srg_item.get("urls", {}):
 
                     download = (
-                        srg_item.get("url", {}).get(url, {}).get("download", False)
+                        ((srg_item.get("urls") or {}).get(url) or {}).get("download", False)
                     )
                     if download:
                         self.logger.info(

--- a/seadexarr/modules/seadex_radarr.py
+++ b/seadexarr/modules/seadex_radarr.py
@@ -209,6 +209,7 @@ class SeaDexRadarr(SeaDexArr):
                             al_id=al_id,
                             release_group=radarr_release_group,
                             seadex_dict=seadex_dict,
+                            arr_release_dict=radarr_release_dict,
                         )
 
                         # If we've got stuff, time to do something!

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -746,11 +746,30 @@ class SeaDexSonarr(SeaDexArr):
                 f"anime[@anidbid='{anidb_id}']"
             )
 
-            # If we don't find anything, no worries. If we find multiple, worries
+            # The AniDB list can carry the same anidbid under more than one
+            # tvdbid (e.g. a title split across TVDB entries). Disambiguate by
+            # the TVDB ID we're actually working with before giving up.
             if len(anidb_item) > 1:
-                raise ValueError(
-                    "Multiple AniDB mappings found. This should not happen!"
+                tvdb_id = get_tvdb_id(mapping)
+                if tvdb_id is not None:
+                    anidb_item = [
+                        a
+                        for a in anidb_item
+                        if a.get("tvdbid") == str(tvdb_id)
+                    ]
+
+            # If we still can't resolve to a single node, skip the AniDB
+            # mapping rather than crashing the whole series — get_ep_list falls
+            # back to the offset slice below.
+            if len(anidb_item) > 1:
+                self.logger.debug(
+                    left_aligned_string(
+                        f"Multiple AniDB mappings for anidbid {anidb_id}; "
+                        f"skipping AniDB episode mapping",
+                        total_length=self.log_line_length,
+                    )
                 )
+                anidb_item = []
 
             if len(anidb_item) == 1:
                 anidb_item = anidb_item[0]

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -796,9 +796,17 @@ class SeaDexSonarr(SeaDexArr):
                             if not anidb_tvdbseason == tvdb_season:
                                 continue
 
-                            anidb_mapping_dict[anidb_tvdbseason] = {
-                                int(x[1]): int(x[0]) for x in i_split
-                            }
+                            # The TVDB side of a mapping can be a '+'-joined
+                            # group (e.g. "1-1+2+3"), meaning one AniDB episode
+                            # spans several TVDB episodes. Expand those so each
+                            # TVDB episode points back at the AniDB episode.
+                            mapping_pairs = {}
+                            for x in i_split:
+                                anidb_ep = int(x[0])
+                                for tvdb_ep in x[1].split("+"):
+                                    mapping_pairs[int(tvdb_ep)] = anidb_ep
+
+                            anidb_mapping_dict[anidb_tvdbseason] = mapping_pairs
 
         # Prefer the AniDB mapping dict over any offsets
         if len(anidb_mapping_dict) > 0:

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -856,13 +856,13 @@ class SeaDexSonarr(SeaDexArr):
                 missing_eps += 1
                 continue
 
-            release_group = ep.get("episodeFile", {}).get("releaseGroup", None)
+            release_group = (ep.get("episodeFile") or {}).get("releaseGroup", None)
             if release_group is None or release_group == "":
                 continue
 
             if release_group not in sonarr_release_dict:
                 sonarr_release_dict[release_group] = {"size": []}
-            size = ep.get("episodeFile", {}).get("size", None)
+            size = (ep.get("episodeFile") or {}).get("size", None)
             sonarr_release_dict[release_group]["size"].append(size)
 
         if missing_eps > 0:

--- a/seadexarr/modules/seadex_sonarr.py
+++ b/seadexarr/modules/seadex_sonarr.py
@@ -501,6 +501,7 @@ class SeaDexSonarr(SeaDexArr):
                             al_id=al_id,
                             release_group=sonarr_release_groups,
                             seadex_dict=seadex_dict,
+                            arr_release_dict=sonarr_release_dict,
                         )
 
                         # If we've got stuff, time to do something!

--- a/seadexarr/modules/sonarr_tags.py
+++ b/seadexarr/modules/sonarr_tags.py
@@ -1,0 +1,86 @@
+import requests
+
+
+class SonarrTagManager:
+    """CRUD for Sonarr tags via direct HTTP — no torrent operations."""
+
+    def __init__(self, sonarr_url: str, sonarr_api_key: str):
+        self._base = sonarr_url.rstrip("/")
+        self._key = sonarr_api_key
+        self._tag_cache: dict[str, int] | None = None
+
+    def _headers(self) -> dict:
+        return {"X-Api-Key": self._key, "Content-Type": "application/json"}
+
+    def get_all_tags(self) -> dict[str, int]:
+        """Return mapping of label → tag id, cached per instance."""
+        if self._tag_cache is not None:
+            return self._tag_cache
+        resp = requests.get(f"{self._base}/api/v3/tag", headers=self._headers())
+        resp.raise_for_status()
+        self._tag_cache = {t["label"]: t["id"] for t in resp.json()}
+        return self._tag_cache
+
+    def get_or_create_tag(self, label: str) -> int:
+        """Return existing tag id or create and return new one."""
+        tags = self.get_all_tags()
+        if label in tags:
+            return tags[label]
+        resp = requests.post(
+            f"{self._base}/api/v3/tag",
+            headers=self._headers(),
+            json={"label": label},
+        )
+        resp.raise_for_status()
+        tag_id = resp.json()["id"]
+        self._tag_cache[label] = tag_id  # type: ignore[index]
+        return tag_id
+
+    def get_series_json(self, series_id: int) -> dict:
+        resp = requests.get(
+            f"{self._base}/api/v3/series/{series_id}",
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def set_series_tags(self, series_id: int, tag_ids: list[int], dry_run: bool = False) -> bool:
+        """Replace the tag list on a series. No-ops when dry_run=True."""
+        if dry_run:
+            return True
+        series_json = self.get_series_json(series_id)
+        series_json["tags"] = tag_ids
+        resp = requests.put(
+            f"{self._base}/api/v3/series/{series_id}",
+            headers=self._headers(),
+            json=series_json,
+        )
+        resp.raise_for_status()
+        return True
+
+    def compute_tag_changes(
+        self,
+        current_tag_ids: list[int],
+        desired_labels: list[str],
+        managed_labels: list[str],
+        remove_stale: bool,
+    ) -> tuple[list[int], bool]:
+        """Compute final tag id list for a series.
+
+        Returns (new_tag_ids, changed). Only removes tags from managed_labels
+        when remove_stale=True — never removes tags the user added manually.
+        """
+        all_tags = self.get_all_tags()
+        managed_ids = {all_tags[l] for l in managed_labels if l in all_tags}
+        desired_ids = {self.get_or_create_tag(l) for l in desired_labels}
+
+        current_set = set(current_tag_ids)
+
+        if remove_stale:
+            non_managed = current_set - managed_ids
+            final = non_managed | desired_ids
+        else:
+            final = current_set | desired_ids
+
+        changed = final != current_set
+        return sorted(final), changed

--- a/seadexarr/modules/sonarr_tags.py
+++ b/seadexarr/modules/sonarr_tags.py
@@ -67,8 +67,9 @@ class SonarrTagManager:
     ) -> tuple[list[int], bool]:
         """Compute final tag id list for a series.
 
-        Returns (new_tag_ids, changed). Only removes tags from managed_labels
-        when remove_stale=True — never removes tags the user added manually.
+        Returns (new_tag_ids, changed). Managed tags are always kept in sync
+        (added when desired, removed when not). remove_stale controls whether
+        unrecognised non-managed tags the user added manually are also swept.
         """
         all_tags = self.get_all_tags()
         managed_ids = {all_tags[l] for l in managed_labels if l in all_tags}
@@ -76,11 +77,12 @@ class SonarrTagManager:
 
         current_set = set(current_tag_ids)
 
-        if remove_stale:
-            non_managed = current_set - managed_ids
-            final = non_managed | desired_ids
-        else:
-            final = current_set | desired_ids
+        # Managed tags are always kept in sync: old ones not in desired_ids are
+        # dropped, new desired ones are added. User-added non-managed tags are
+        # always preserved. remove_stale is kept for API compatibility but has
+        # no effect — managed tags are always synced.
+        non_managed = current_set - managed_ids
+        final = non_managed | desired_ids
 
         changed = final != current_set
         return sorted(final), changed

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -503,5 +503,89 @@ class TestEmbedColour(unittest.TestCase):
         self.assertEqual(SeaDexAudit._embed_colour(r), _COLOUR_PARTIAL)
 
 
+# ---------------------------------------------------------------------------
+# alt_is_acceptable
+# ---------------------------------------------------------------------------
+
+class TestAltIsAcceptable(unittest.TestCase):
+
+    def _make_audit(self, alt_is_acceptable=False):
+        audit = SeaDexAudit.__new__(SeaDexAudit)
+        audit.alt_is_acceptable = alt_is_acceptable
+        audit.size_filter_enabled = False
+        audit.ignore_tags = []
+        audit.trackers = ["animetosho"]
+        audit.public_only = False
+        audit.log_line_length = 80
+        audit.logger = MagicMock()
+        audit.al_cache = {}
+        return audit
+
+    def _make_torrent(self, release_group, is_best, tracker="animetosho"):
+        t = MagicMock()
+        t.release_group = release_group
+        t.is_best = is_best
+        t.tags = []
+        t.tracker = MagicMock()
+        t.tracker.lower.return_value = tracker
+        t.tracker.is_public.return_value = True
+        t.url = f"https://example.com/{release_group}"
+        t.files = []
+        t.infohash = "abc123"
+        t.is_dual_audio = False
+        return t
+
+    def _run(self, audit, library_rgs, sd_torrents):
+        mock_series = MagicMock()
+        mock_series.id = 1
+        mock_series.title = "Test Show"
+
+        mock_sd_entry = MagicMock()
+        mock_sd_entry.url = "https://seadex.moe/test"
+        mock_sd_entry.torrents = sd_torrents
+
+        release_dict = {rg: {"size": [1_000_000_000]} for rg in library_rgs}
+        seadex_dict = {"BestGroup": {"urls": {}}}
+
+        with patch.object(audit, "get_seadex_entry", return_value=mock_sd_entry), \
+             patch.object(audit, "get_anilist_title", return_value="Test Show"), \
+             patch.object(audit, "get_ep_list", return_value=[]), \
+             patch.object(audit, "get_sonarr_release_dict", return_value=release_dict), \
+             patch.object(audit, "get_seadex_dict", return_value=seadex_dict), \
+             patch.object(audit, "_sum_seadex_size", return_value=2_000_000_000), \
+             patch.object(audit, "parse_episodes_from_seadex", return_value=seadex_dict), \
+             patch.object(audit, "filter_seadex_downloads", return_value=(True, seadex_dict)), \
+             patch.object(audit, "get_any_to_download", return_value=True):
+            return audit._audit_al_id(mock_series, 12345, {})
+
+    def test_alt_acceptable_library_has_alt_clears_upgrade(self):
+        audit = self._make_audit(alt_is_acceptable=True)
+        torrents = [
+            self._make_torrent("BestGroup", is_best=True),
+            self._make_torrent("AltGroup", is_best=False),
+        ]
+        result = self._run(audit, library_rgs=["AltGroup"], sd_torrents=torrents)
+        self.assertFalse(result["upgrade_available"])
+        self.assertFalse(result["too_large"])
+
+    def test_alt_not_acceptable_upgrade_stays(self):
+        audit = self._make_audit(alt_is_acceptable=False)
+        torrents = [
+            self._make_torrent("BestGroup", is_best=True),
+            self._make_torrent("AltGroup", is_best=False),
+        ]
+        result = self._run(audit, library_rgs=["AltGroup"], sd_torrents=torrents)
+        self.assertTrue(result["upgrade_available"])
+
+    def test_library_not_in_seadex_upgrade_stays(self):
+        audit = self._make_audit(alt_is_acceptable=True)
+        torrents = [
+            self._make_torrent("BestGroup", is_best=True),
+            self._make_torrent("AltGroup", is_best=False),
+        ]
+        result = self._run(audit, library_rgs=["SomeRandomGroup"], sd_torrents=torrents)
+        self.assertTrue(result["upgrade_available"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -373,7 +373,9 @@ class TestTagDiff(unittest.TestCase):
         self.assertNotIn(2, new_ids)
         self.assertTrue(changed)
 
-    def test_stale_managed_tag_not_removed_when_disabled(self):
+    def test_stale_managed_tag_removed_regardless_of_remove_stale(self):
+        # Managed tags are always kept in sync — remove_stale=False should
+        # no longer preserve a managed tag that is no longer desired.
         mgr = self._manager({"seadex": 1, "seadex-upgrade-available": 2})
         with patch.object(mgr, "get_or_create_tag", side_effect=lambda l: mgr._tag_cache.get(l, 99)):
             new_ids, changed = mgr.compute_tag_changes(
@@ -383,8 +385,8 @@ class TestTagDiff(unittest.TestCase):
                 remove_stale=False,
             )
         self.assertIn(1, new_ids)
-        self.assertIn(2, new_ids)
-        self.assertFalse(changed)
+        self.assertNotIn(2, new_ids)
+        self.assertTrue(changed)
 
     def test_user_tags_never_removed(self):
         mgr = self._manager({"seadex": 1})
@@ -585,6 +587,31 @@ class TestAltIsAcceptable(unittest.TestCase):
         ]
         result = self._run(audit, library_rgs=["SomeRandomGroup"], sd_torrents=torrents)
         self.assertTrue(result["upgrade_available"])
+
+    def test_alt_acceptable_public_only_filters_private_tracker(self):
+        """With public_only=True, private-tracker-only alts don't suppress upgrade."""
+        audit = self._make_audit(alt_is_acceptable=True)
+        audit.public_only = True
+        audit.trackers = ["nyaa", "animetosho"]
+
+        best = self._make_torrent("BestGroup", is_best=True, tracker="nyaa")
+        alt_private = self._make_torrent("AltGroup", is_best=False, tracker="ab")
+        alt_private.tracker.is_public.return_value = False
+
+        result = self._run(audit, library_rgs=["AltGroup"], sd_torrents=[best, alt_private])
+        self.assertTrue(result["upgrade_available"])
+
+    def test_alt_acceptable_public_only_public_alt_clears_upgrade(self):
+        """With public_only=True, a public-tracker alt in the library suppresses upgrade."""
+        audit = self._make_audit(alt_is_acceptable=True)
+        audit.public_only = True
+        audit.trackers = ["nyaa", "animetosho"]
+
+        best = self._make_torrent("BestGroup", is_best=True, tracker="nyaa")
+        alt_public = self._make_torrent("AltGroup", is_best=False, tracker="nyaa")
+
+        result = self._run(audit, library_rgs=["AltGroup"], sd_torrents=[best, alt_public])
+        self.assertFalse(result["upgrade_available"])
 
 
 if __name__ == "__main__":

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -613,6 +613,113 @@ class TestAltIsAcceptable(unittest.TestCase):
         result = self._run(audit, library_rgs=["AltGroup"], sd_torrents=[best, alt_public])
         self.assertFalse(result["upgrade_available"])
 
+    def _filter_kwarg(self, audit, library_rgs, sd_torrents):
+        """Run an audit and return the acceptable_alt_owned kwarg that
+        _audit_al_id passed down to filter_seadex_downloads."""
+        mock_series = MagicMock()
+        mock_series.id = 1
+        mock_series.title = "Test Show"
+
+        mock_sd_entry = MagicMock()
+        mock_sd_entry.url = "https://seadex.moe/test"
+        mock_sd_entry.torrents = sd_torrents
+
+        release_dict = {rg: {"size": [1_000_000_000]} for rg in library_rgs}
+        seadex_dict = {"BestGroup": {"urls": {}}}
+        mock_filter = MagicMock(return_value=(True, seadex_dict))
+
+        with patch.object(audit, "get_seadex_entry", return_value=mock_sd_entry), \
+             patch.object(audit, "get_anilist_title", return_value="Test Show"), \
+             patch.object(audit, "get_ep_list", return_value=[]), \
+             patch.object(audit, "get_sonarr_release_dict", return_value=release_dict), \
+             patch.object(audit, "get_seadex_dict", return_value=seadex_dict), \
+             patch.object(audit, "_sum_seadex_size", return_value=2_000_000_000), \
+             patch.object(audit, "parse_episodes_from_seadex", return_value=seadex_dict), \
+             patch.object(audit, "filter_seadex_downloads", mock_filter), \
+             patch.object(audit, "get_any_to_download", return_value=True):
+            audit._audit_al_id(mock_series, 12345, {})
+
+        return mock_filter.call_args.kwargs["acceptable_alt_owned"]
+
+    def test_filter_told_alt_owned_when_library_has_alt(self):
+        audit = self._make_audit(alt_is_acceptable=True)
+        torrents = [
+            self._make_torrent("BestGroup", is_best=True),
+            self._make_torrent("AltGroup", is_best=False),
+        ]
+        self.assertTrue(self._filter_kwarg(audit, ["AltGroup"], torrents))
+
+    def test_filter_not_told_alt_owned_when_library_lacks_seadex_rg(self):
+        audit = self._make_audit(alt_is_acceptable=True)
+        torrents = [
+            self._make_torrent("BestGroup", is_best=True),
+            self._make_torrent("AltGroup", is_best=False),
+        ]
+        self.assertFalse(self._filter_kwarg(audit, ["SomethingElse"], torrents))
+
+    def test_filter_not_told_alt_owned_when_feature_disabled(self):
+        audit = self._make_audit(alt_is_acceptable=False)
+        torrents = [
+            self._make_torrent("BestGroup", is_best=True),
+            self._make_torrent("AltGroup", is_best=False),
+        ]
+        self.assertFalse(self._filter_kwarg(audit, ["AltGroup"], torrents))
+
+
+class TestFilterByReleaseGroupAltLog(unittest.TestCase):
+    """The misleading '→ tagging' line must drop to debug when an owned alt
+    makes the entry acceptable."""
+
+    def _make_arr(self):
+        from seadexarr.modules.seadex_arr import SeaDexArr
+        arr = SeaDexArr.__new__(SeaDexArr)
+        arr.audit_mode = True
+        arr.use_torrent_hash_to_filter = False
+        arr.log_line_length = 80
+        arr.logger = MagicMock()
+        return arr
+
+    def _seadex_dict(self):
+        return {
+            "BestGroup": {
+                "tags": [],
+                "urls": {
+                    "https://example.com/best": {
+                        "hash": "h1",
+                        "size": [28_000_000_000],
+                        "episodes": [],
+                        "download": False,
+                    }
+                },
+            }
+        }
+
+    def test_owned_alt_demotes_tagging_log_to_debug(self):
+        arr = self._make_arr()
+        arr.filter_by_release_group(
+            seadex_dict=self._seadex_dict(),
+            arr="sonarr",
+            arr_release_dict={"AltGroup": {"size": [9_000_000_000]}},
+            ep_list=[],
+            acceptable_alt_owned=True,
+        )
+        info_msgs = " ".join(str(c.args[0]) for c in arr.logger.info.call_args_list)
+        debug_msgs = " ".join(str(c.args[0]) for c in arr.logger.debug.call_args_list)
+        self.assertNotIn("tagging", info_msgs)
+        self.assertIn("have acceptable alt", debug_msgs)
+
+    def test_no_alt_keeps_tagging_log_at_info(self):
+        arr = self._make_arr()
+        arr.filter_by_release_group(
+            seadex_dict=self._seadex_dict(),
+            arr="sonarr",
+            arr_release_dict={"AltGroup": {"size": [9_000_000_000]}},
+            ep_list=[],
+            acceptable_alt_owned=False,
+        )
+        info_msgs = " ".join(str(c.args[0]) for c in arr.logger.info.call_args_list)
+        self.assertIn("tagging", info_msgs)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,365 @@
+"""
+Unit tests for audit mode.
+
+Tests cover status classification, state deduplication, tag diff logic,
+dry-run guards, and stale tag removal scoping.
+
+Run with: python -m pytest tests/test_audit.py -v
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from seadexarr.modules.audit import AuditResult, SeaDexAudit
+from seadexarr.modules.audit_state import AuditState, SeriesAuditState, state_changed
+from seadexarr.modules.sonarr_tags import SonarrTagManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_result(**kwargs) -> AuditResult:
+    defaults = dict(
+        sonarr_id=1,
+        tvdb_id=100,
+        sonarr_title="Test Show",
+        anilist_title="Test Show",
+        al_id=999,
+        sd_url="https://seadex.moe/foo",
+        seadex_status="none",
+    )
+    defaults.update(kwargs)
+    return AuditResult(**defaults)
+
+
+def _make_state(**kwargs) -> SeriesAuditState:
+    defaults = dict(
+        sonarr_id=1,
+        tvdb_id=100,
+        title="Test Show",
+        seadex_status="none",
+    )
+    defaults.update(kwargs)
+    return SeriesAuditState(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Status classification
+# ---------------------------------------------------------------------------
+
+class TestStatusClassification(unittest.TestCase):
+
+    def test_no_seadex_entry_is_none(self):
+        r = _make_result(seadex_status="none")
+        self.assertEqual(r.seadex_status, "none")
+
+    def test_partial_when_entry_but_no_filtered_releases(self):
+        r = _make_result(seadex_status="partial")
+        self.assertEqual(r.seadex_status, "partial")
+        self.assertFalse(r.upgrade_available)
+
+    def test_full_when_seadex_releases_available(self):
+        r = _make_result(
+            seadex_status="full",
+            seadex_rgs=["SubsPlease"],
+            upgrade_available=False,
+        )
+        self.assertEqual(r.seadex_status, "full")
+
+    def test_upgrade_available_set_independently(self):
+        r = _make_result(seadex_status="full", upgrade_available=True, too_large=False)
+        self.assertTrue(r.upgrade_available)
+        self.assertFalse(r.too_large)
+
+    def test_too_large_requires_upgrade_available(self):
+        r = _make_result(seadex_status="full", upgrade_available=True, too_large=True)
+        self.assertTrue(r.too_large)
+
+    def test_desired_tags_full_no_upgrade(self):
+        audit = self._make_audit_instance()
+        r = _make_result(seadex_status="full", upgrade_available=False)
+        tags = audit._compute_desired_tags(r)
+        self.assertIn(audit.tag_full, tags)
+        self.assertNotIn(audit.tag_upgrade, tags)
+        self.assertNotIn(audit.tag_too_large, tags)
+
+    def test_desired_tags_partial(self):
+        audit = self._make_audit_instance()
+        r = _make_result(seadex_status="partial")
+        tags = audit._compute_desired_tags(r)
+        self.assertIn(audit.tag_partial, tags)
+        self.assertNotIn(audit.tag_full, tags)
+
+    def test_desired_tags_upgrade_available(self):
+        audit = self._make_audit_instance()
+        r = _make_result(seadex_status="full", upgrade_available=True, too_large=False)
+        tags = audit._compute_desired_tags(r)
+        self.assertIn(audit.tag_full, tags)
+        self.assertIn(audit.tag_upgrade, tags)
+        self.assertNotIn(audit.tag_too_large, tags)
+
+    def test_desired_tags_too_large(self):
+        audit = self._make_audit_instance()
+        r = _make_result(seadex_status="full", upgrade_available=True, too_large=True)
+        tags = audit._compute_desired_tags(r)
+        self.assertIn(audit.tag_full, tags)
+        self.assertIn(audit.tag_too_large, tags)
+        self.assertNotIn(audit.tag_upgrade, tags)
+
+    def test_none_status_no_tags(self):
+        audit = self._make_audit_instance()
+        r = _make_result(seadex_status="none")
+        tags = audit._compute_desired_tags(r)
+        self.assertEqual(tags, [])
+
+    def _make_audit_instance(self):
+        audit = SeaDexAudit.__new__(SeaDexAudit)
+        audit.tag_full = "seadex"
+        audit.tag_partial = "partial-seadex"
+        audit.tag_upgrade = "seadex-upgrade-available"
+        audit.tag_too_large = "seadex-too-large"
+        audit.tag_ignored = "seadex-ignored"
+        audit.tag_when_too_large = True
+        return audit
+
+
+# ---------------------------------------------------------------------------
+# State deduplication
+# ---------------------------------------------------------------------------
+
+class TestStateDeduplication(unittest.TestCase):
+
+    def test_none_old_always_changed(self):
+        new = _make_state(seadex_status="full")
+        self.assertTrue(state_changed(None, new))
+
+    def test_identical_state_no_change(self):
+        s = _make_state(seadex_status="full", seadex_rgs=["SubsPlease"])
+        self.assertFalse(state_changed(s, s))
+
+    def test_status_flip_is_change(self):
+        old = _make_state(seadex_status="none")
+        new = _make_state(seadex_status="full")
+        self.assertTrue(state_changed(old, new))
+
+    def test_rg_change_is_change(self):
+        old = _make_state(seadex_status="full", seadex_rgs=["GroupA"])
+        new = _make_state(seadex_status="full", seadex_rgs=["GroupB"])
+        self.assertTrue(state_changed(old, new))
+
+    def test_upgrade_flip_is_change(self):
+        old = _make_state(upgrade_available=False)
+        new = _make_state(upgrade_available=True)
+        self.assertTrue(state_changed(old, new))
+
+    def test_should_notify_first_seadex_match(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            state = AuditState(path)
+            new = _make_state(seadex_status="full")
+            cfg = {"notify_on_new_seadex_match": True}
+            self.assertTrue(state.should_notify(new, cfg))
+        finally:
+            os.unlink(path)
+
+    def test_should_not_notify_no_change(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            state = AuditState(path)
+            existing = _make_state(seadex_status="full", upgrade_available=False)
+            state.update_series(existing)
+            new = _make_state(seadex_status="full", upgrade_available=False)
+            cfg = {"notify_on_no_change": False}
+            self.assertFalse(state.should_notify(new, cfg))
+        finally:
+            os.unlink(path)
+
+    def test_should_notify_new_upgrade(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            state = AuditState(path)
+            old = _make_state(seadex_status="full", upgrade_available=False)
+            state.update_series(old)
+            new = _make_state(seadex_status="full", upgrade_available=True)
+            cfg = {"notify_on_new_upgrade_available": True}
+            self.assertTrue(state.should_notify(new, cfg))
+        finally:
+            os.unlink(path)
+
+    def test_state_persists_across_load(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            state = AuditState(path)
+            s = _make_state(sonarr_id=42, seadex_status="full")
+            state.update_series(s)
+            state.save()
+
+            state2 = AuditState(path)
+            loaded = state2.get_series(42)
+            self.assertIsNotNone(loaded)
+            self.assertEqual(loaded.seadex_status, "full")
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Tag diff calculation
+# ---------------------------------------------------------------------------
+
+class TestTagDiff(unittest.TestCase):
+
+    def _manager(self, existing_tags: dict[str, int]) -> SonarrTagManager:
+        mgr = SonarrTagManager.__new__(SonarrTagManager)
+        mgr._base = "http://sonarr:8989"
+        mgr._key = "testkey"
+        mgr._tag_cache = dict(existing_tags)
+        return mgr
+
+    def test_add_new_tag(self):
+        mgr = self._manager({"seadex": 1})
+        with patch.object(mgr, "get_or_create_tag", side_effect=lambda l: mgr._tag_cache.get(l, 99)):
+            new_ids, changed = mgr.compute_tag_changes(
+                current_tag_ids=[],
+                desired_labels=["seadex"],
+                managed_labels=["seadex"],
+                remove_stale=False,
+            )
+        self.assertIn(1, new_ids)
+        self.assertTrue(changed)
+
+    def test_no_change_when_tag_already_present(self):
+        mgr = self._manager({"seadex": 1})
+        with patch.object(mgr, "get_or_create_tag", side_effect=lambda l: 1):
+            new_ids, changed = mgr.compute_tag_changes(
+                current_tag_ids=[1],
+                desired_labels=["seadex"],
+                managed_labels=["seadex"],
+                remove_stale=False,
+            )
+        self.assertFalse(changed)
+
+    def test_stale_managed_tag_removed_when_enabled(self):
+        mgr = self._manager({"seadex": 1, "seadex-upgrade-available": 2})
+        with patch.object(mgr, "get_or_create_tag", side_effect=lambda l: mgr._tag_cache.get(l, 99)):
+            # currently has both tags; desired is only seadex; stale removal ON
+            new_ids, changed = mgr.compute_tag_changes(
+                current_tag_ids=[1, 2],
+                desired_labels=["seadex"],
+                managed_labels=["seadex", "seadex-upgrade-available"],
+                remove_stale=True,
+            )
+        self.assertIn(1, new_ids)
+        self.assertNotIn(2, new_ids)
+        self.assertTrue(changed)
+
+    def test_stale_managed_tag_not_removed_when_disabled(self):
+        mgr = self._manager({"seadex": 1, "seadex-upgrade-available": 2})
+        with patch.object(mgr, "get_or_create_tag", side_effect=lambda l: mgr._tag_cache.get(l, 99)):
+            new_ids, changed = mgr.compute_tag_changes(
+                current_tag_ids=[1, 2],
+                desired_labels=["seadex"],
+                managed_labels=["seadex", "seadex-upgrade-available"],
+                remove_stale=False,
+            )
+        self.assertIn(1, new_ids)
+        self.assertIn(2, new_ids)  # kept because remove_stale=False
+        self.assertFalse(changed)
+
+    def test_user_tags_never_removed(self):
+        mgr = self._manager({"seadex": 1})
+        user_tag_id = 99  # not in managed_labels
+        with patch.object(mgr, "get_or_create_tag", side_effect=lambda l: mgr._tag_cache.get(l, 1)):
+            new_ids, _ = mgr.compute_tag_changes(
+                current_tag_ids=[user_tag_id, 1],
+                desired_labels=["seadex"],
+                managed_labels=["seadex"],
+                remove_stale=True,
+            )
+        self.assertIn(user_tag_id, new_ids)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run: no Sonarr mutation endpoints called
+# ---------------------------------------------------------------------------
+
+class TestDryRun(unittest.TestCase):
+
+    def test_set_series_tags_noop_in_dry_run(self):
+        mgr = SonarrTagManager.__new__(SonarrTagManager)
+        mgr._base = "http://sonarr:8989"
+        mgr._key = "key"
+        mgr._tag_cache = {}
+
+        with patch("seadexarr.modules.sonarr_tags.requests.put") as mock_put, \
+             patch.object(mgr, "get_series_json", return_value={"id": 1, "tags": []}):
+            result = mgr.set_series_tags(series_id=1, tag_ids=[2, 3], dry_run=True)
+
+        mock_put.assert_not_called()
+        self.assertTrue(result)
+
+    def test_audit_run_dry_run_does_not_call_set_series_tags(self):
+        """In dry_run mode, _apply_series_tags must not call set_series_tags."""
+        audit = SeaDexAudit.__new__(SeaDexAudit)
+        audit.tag_full = "seadex"
+        audit.tag_partial = "partial-seadex"
+        audit.tag_upgrade = "seadex-upgrade-available"
+        audit.tag_too_large = "seadex-too-large"
+        audit.tag_ignored = "seadex-ignored"
+        audit.managed_tag_labels = [audit.tag_full, audit.tag_partial,
+                                     audit.tag_upgrade, audit.tag_too_large,
+                                     audit.tag_ignored]
+        audit.audit_remove_stale = False
+        audit.log_line_length = 80
+        audit.logger = MagicMock()
+
+        mock_tm = MagicMock()
+        mock_tm.get_series_json.return_value = {"id": 1, "tags": []}
+        mock_tm.compute_tag_changes.return_value = ([5], True)
+        audit.tag_manager = mock_tm
+
+        mock_series = MagicMock()
+        mock_series.id = 1
+        result = _make_result(seadex_status="full", desired_tags=["seadex"])
+
+        audit._apply_series_tags(mock_series, result, dry_run=True)
+
+        mock_tm.set_series_tags.assert_called_once_with(1, [5], dry_run=True)
+
+
+# ---------------------------------------------------------------------------
+# Stale tag removal only touches managed tags
+# ---------------------------------------------------------------------------
+
+class TestStaleTagRemoval(unittest.TestCase):
+
+    def test_only_managed_labels_considered_for_removal(self):
+        mgr = SonarrTagManager.__new__(SonarrTagManager)
+        mgr._base = "http://sonarr"
+        mgr._key = "key"
+        mgr._tag_cache = {"seadex": 10, "partial-seadex": 20}
+
+        arbitrary_user_tag = 777
+
+        with patch.object(mgr, "get_or_create_tag", side_effect=lambda l: mgr._tag_cache[l]):
+            new_ids, _ = mgr.compute_tag_changes(
+                current_tag_ids=[10, 20, arbitrary_user_tag],
+                desired_labels=["seadex"],
+                managed_labels=["seadex", "partial-seadex"],
+                remove_stale=True,
+            )
+
+        self.assertIn(10, new_ids)     # desired
+        self.assertNotIn(20, new_ids)  # stale managed, removed
+        self.assertIn(arbitrary_user_tag, new_ids)  # user tag, kept
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -2,7 +2,8 @@
 Unit tests for audit mode.
 
 Tests cover status classification, state deduplication, tag diff logic,
-dry-run guards, and stale tag removal scoping.
+dry-run guards, stale tag removal scoping, SQLite persistence, JSON migration,
+and Discord diff generation.
 
 Run with: python -m pytest tests/test_audit.py -v
 """
@@ -11,10 +12,15 @@ import json
 import os
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 from seadexarr.modules.audit import AuditResult, SeaDexAudit
-from seadexarr.modules.audit_state import AuditState, SeriesAuditState, state_changed
+from seadexarr.modules.audit_state import (
+    AuditState,
+    SeriesAuditState,
+    rg_diff,
+    state_changed,
+)
 from seadexarr.modules.sonarr_tags import SonarrTagManager
 
 
@@ -45,6 +51,13 @@ def _make_state(**kwargs) -> SeriesAuditState:
     )
     defaults.update(kwargs)
     return SeriesAuditState(**defaults)
+
+
+def _tmp_db() -> str:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    os.unlink(path)   # SQLite creates its own file
+    return path
 
 
 # ---------------------------------------------------------------------------
@@ -157,19 +170,19 @@ class TestStateDeduplication(unittest.TestCase):
         self.assertTrue(state_changed(old, new))
 
     def test_should_notify_first_seadex_match(self):
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            path = f.name
+        path = _tmp_db()
         try:
             state = AuditState(path)
             new = _make_state(seadex_status="full")
             cfg = {"notify_on_new_seadex_match": True}
             self.assertTrue(state.should_notify(new, cfg))
         finally:
-            os.unlink(path)
+            state.close()
+            if os.path.exists(path):
+                os.unlink(path)
 
     def test_should_not_notify_no_change(self):
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            path = f.name
+        path = _tmp_db()
         try:
             state = AuditState(path)
             existing = _make_state(seadex_status="full", upgrade_available=False)
@@ -178,11 +191,12 @@ class TestStateDeduplication(unittest.TestCase):
             cfg = {"notify_on_no_change": False}
             self.assertFalse(state.should_notify(new, cfg))
         finally:
-            os.unlink(path)
+            state.close()
+            if os.path.exists(path):
+                os.unlink(path)
 
     def test_should_notify_new_upgrade(self):
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            path = f.name
+        path = _tmp_db()
         try:
             state = AuditState(path)
             old = _make_state(seadex_status="full", upgrade_available=False)
@@ -191,23 +205,123 @@ class TestStateDeduplication(unittest.TestCase):
             cfg = {"notify_on_new_upgrade_available": True}
             self.assertTrue(state.should_notify(new, cfg))
         finally:
-            os.unlink(path)
+            state.close()
+            if os.path.exists(path):
+                os.unlink(path)
 
     def test_state_persists_across_load(self):
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            path = f.name
+        path = _tmp_db()
         try:
             state = AuditState(path)
             s = _make_state(sonarr_id=42, seadex_status="full")
             state.update_series(s)
-            state.save()
+            state.close()
 
             state2 = AuditState(path)
             loaded = state2.get_series(42)
             self.assertIsNotNone(loaded)
             self.assertEqual(loaded.seadex_status, "full")
+            state2.close()
         finally:
-            os.unlink(path)
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# SQLite-specific: migration from JSON
+# ---------------------------------------------------------------------------
+
+class TestJsonMigration(unittest.TestCase):
+
+    def test_migrates_from_legacy_json(self):
+        fd, json_path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        db_path = json_path[:-5] + ".db"
+        try:
+            # Write legacy JSON state
+            legacy = {
+                "schema_version": 1,
+                "series": {
+                    "7": {
+                        "sonarr_id": 7,
+                        "tvdb_id": 123,
+                        "title": "Migrated Show",
+                        "seadex_status": "full",
+                        "seadex_rgs": ["SubsPlease"],
+                        "seadex_size_bytes": 1000,
+                        "library_rgs": [],
+                        "upgrade_available": False,
+                        "too_large": False,
+                        "last_notified": None,
+                        "last_audited": "2024-01-01T00:00:00+00:00",
+                    }
+                },
+            }
+            with open(json_path, "w") as f:
+                json.dump(legacy, f)
+
+            # AuditState with .json path triggers migration
+            state = AuditState(json_path)
+            loaded = state.get_series(7)
+            self.assertIsNotNone(loaded)
+            self.assertEqual(loaded.title, "Migrated Show")
+            self.assertEqual(loaded.seadex_rgs, ["SubsPlease"])
+            state.close()
+
+            # JSON file should have been renamed
+            self.assertFalse(os.path.exists(json_path))
+            self.assertTrue(os.path.exists(json_path + ".migrated"))
+        finally:
+            for p in (json_path, json_path + ".migrated", db_path):
+                if os.path.exists(p):
+                    os.unlink(p)
+
+    def test_empty_json_migrates_cleanly(self):
+        fd, json_path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        db_path = json_path[:-5] + ".db"
+        try:
+            # Empty JSON — should not crash
+            state = AuditState(json_path)
+            state.close()
+        finally:
+            for p in (json_path, json_path + ".migrated", db_path):
+                if os.path.exists(p):
+                    os.unlink(p)
+
+
+# ---------------------------------------------------------------------------
+# Release-group diff
+# ---------------------------------------------------------------------------
+
+class TestRgDiff(unittest.TestCase):
+
+    def test_no_old_state_all_rgs_are_added(self):
+        new = _make_state(seadex_rgs=["SubsPlease", "Erai-raws"])
+        added, removed = rg_diff(None, new)
+        self.assertEqual(set(added), {"SubsPlease", "Erai-raws"})
+        self.assertEqual(removed, [])
+
+    def test_rg_replaced(self):
+        old = _make_state(seadex_rgs=["Erai-raws"])
+        new = _make_state(seadex_rgs=["SubsPlease"])
+        added, removed = rg_diff(old, new)
+        self.assertIn("SubsPlease", added)
+        self.assertIn("Erai-raws", removed)
+
+    def test_no_change_empty_diff(self):
+        old = _make_state(seadex_rgs=["SubsPlease"])
+        new = _make_state(seadex_rgs=["SubsPlease"])
+        added, removed = rg_diff(old, new)
+        self.assertEqual(added, [])
+        self.assertEqual(removed, [])
+
+    def test_rg_added_without_removal(self):
+        old = _make_state(seadex_rgs=["SubsPlease"])
+        new = _make_state(seadex_rgs=["SubsPlease", "Erai-raws"])
+        added, removed = rg_diff(old, new)
+        self.assertIn("Erai-raws", added)
+        self.assertEqual(removed, [])
 
 
 # ---------------------------------------------------------------------------
@@ -249,7 +363,6 @@ class TestTagDiff(unittest.TestCase):
     def test_stale_managed_tag_removed_when_enabled(self):
         mgr = self._manager({"seadex": 1, "seadex-upgrade-available": 2})
         with patch.object(mgr, "get_or_create_tag", side_effect=lambda l: mgr._tag_cache.get(l, 99)):
-            # currently has both tags; desired is only seadex; stale removal ON
             new_ids, changed = mgr.compute_tag_changes(
                 current_tag_ids=[1, 2],
                 desired_labels=["seadex"],
@@ -270,12 +383,12 @@ class TestTagDiff(unittest.TestCase):
                 remove_stale=False,
             )
         self.assertIn(1, new_ids)
-        self.assertIn(2, new_ids)  # kept because remove_stale=False
+        self.assertIn(2, new_ids)
         self.assertFalse(changed)
 
     def test_user_tags_never_removed(self):
         mgr = self._manager({"seadex": 1})
-        user_tag_id = 99  # not in managed_labels
+        user_tag_id = 99
         with patch.object(mgr, "get_or_create_tag", side_effect=lambda l: mgr._tag_cache.get(l, 1)):
             new_ids, _ = mgr.compute_tag_changes(
                 current_tag_ids=[user_tag_id, 1],
@@ -306,7 +419,6 @@ class TestDryRun(unittest.TestCase):
         self.assertTrue(result)
 
     def test_audit_run_dry_run_does_not_call_set_series_tags(self):
-        """In dry_run mode, _apply_series_tags must not call set_series_tags."""
         audit = SeaDexAudit.__new__(SeaDexAudit)
         audit.tag_full = "seadex"
         audit.tag_partial = "partial-seadex"
@@ -356,9 +468,39 @@ class TestStaleTagRemoval(unittest.TestCase):
                 remove_stale=True,
             )
 
-        self.assertIn(10, new_ids)     # desired
-        self.assertNotIn(20, new_ids)  # stale managed, removed
-        self.assertIn(arbitrary_user_tag, new_ids)  # user tag, kept
+        self.assertIn(10, new_ids)
+        self.assertNotIn(20, new_ids)
+        self.assertIn(arbitrary_user_tag, new_ids)
+
+
+# ---------------------------------------------------------------------------
+# Embed colour helper
+# ---------------------------------------------------------------------------
+
+class TestEmbedColour(unittest.TestCase):
+
+    def _audit(self):
+        return SeaDexAudit.__new__(SeaDexAudit)
+
+    def test_too_large_colour(self):
+        from seadexarr.modules.audit import _COLOUR_TOO_LARGE
+        r = _make_result(seadex_status="full", upgrade_available=True, too_large=True)
+        self.assertEqual(SeaDexAudit._embed_colour(r), _COLOUR_TOO_LARGE)
+
+    def test_upgrade_colour(self):
+        from seadexarr.modules.audit import _COLOUR_UPGRADE
+        r = _make_result(seadex_status="full", upgrade_available=True, too_large=False)
+        self.assertEqual(SeaDexAudit._embed_colour(r), _COLOUR_UPGRADE)
+
+    def test_full_colour(self):
+        from seadexarr.modules.audit import _COLOUR_FULL
+        r = _make_result(seadex_status="full", upgrade_available=False)
+        self.assertEqual(SeaDexAudit._embed_colour(r), _COLOUR_FULL)
+
+    def test_partial_colour(self):
+        from seadexarr.modules.audit import _COLOUR_PARTIAL
+        r = _make_result(seadex_status="partial")
+        self.assertEqual(SeaDexAudit._embed_colour(r), _COLOUR_PARTIAL)
 
 
 if __name__ == "__main__":

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -65,6 +65,44 @@ _SONARR_EPISODES = [
 ]
 
 
+# AniDB fragment where one AniDB episode spans several TVDB episodes via a
+# '+'-joined group ("1-1+2+3"): the Burn the Witch case that crashed int().
+_ANIDB_XML_PLUS = """
+<anime-list>
+  <anime anidbid="16321" tvdbid="389481" defaulttvdbseason="0">
+    <name>Burn the Witch</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-1+2+3;</mapping>
+    </mapping-list>
+  </anime>
+</anime-list>
+"""
+
+_SONARR_EPISODES_PLUS = [
+    {
+        "seasonNumber": 0,
+        "episodeNumber": 1,
+        "episodeFileId": 1,
+        "monitored": True,
+        "episodeFile": {"releaseGroup": "GroupA", "size": 1_000_000_000},
+    },
+    {
+        "seasonNumber": 0,
+        "episodeNumber": 2,
+        "episodeFileId": 2,
+        "monitored": True,
+        "episodeFile": {"releaseGroup": "GroupA", "size": 1_000_000_000},
+    },
+    {
+        "seasonNumber": 0,
+        "episodeNumber": 3,
+        "episodeFileId": 3,
+        "monitored": True,
+        "episodeFile": {"releaseGroup": "GroupA", "size": 1_000_000_000},
+    },
+]
+
+
 def _make_arr() -> SeaDexArr:
     arr = SeaDexArr.__new__(SeaDexArr)
     arr.anime_mappings = _ANIME_IDS
@@ -119,12 +157,12 @@ class TestAnimeMappingAnidbId(unittest.TestCase):
 
 class TestGetEpListSpecial(unittest.TestCase):
 
-    def _run_get_ep_list(self, mapping, anidb_mappings):
+    def _run_get_ep_list(self, mapping, anidb_mappings, episodes=None, al_id=119113):
         s = _make_sonarr(anidb_mappings)
 
         resp = MagicMock()
         resp.status_code = 200
-        resp.json.return_value = list(_SONARR_EPISODES)
+        resp.json.return_value = list(episodes or _SONARR_EPISODES)
 
         with patch(
             "seadexarr.modules.seadex_sonarr.requests.get", return_value=resp
@@ -137,7 +175,7 @@ class TestGetEpListSpecial(unittest.TestCase):
         ):
             return s.get_ep_list(
                 sonarr_series_id=63,
-                al_id=119113,
+                al_id=al_id,
                 mapping=mapping,
             )
 
@@ -174,6 +212,27 @@ class TestGetEpListSpecial(unittest.TestCase):
         self.assertEqual(len(ep_list), 1)
         self.assertEqual(ep_list[0]["episodeNumber"], 1)
         self.assertEqual(ep_list[0]["episodeFileId"], 0)
+
+
+    def test_plus_grouped_mapping_expands_to_all_tvdb_episodes(self):
+        """A '+'-joined TVDB group ("1-1+2+3") maps one AniDB ep to several
+        TVDB eps without crashing int() (Burn the Witch regression)."""
+        root = ElementTree.fromstring(_ANIDB_XML_PLUS)
+        mapping = {
+            "tvdb_id": 389481,
+            "tvdb_season": 0,
+            "tvdb_epoffset": 0,
+            "anilist_id": 116673,
+            "anidb_id": "16321",
+        }
+
+        ep_list = self._run_get_ep_list(
+            mapping, root, episodes=_SONARR_EPISODES_PLUS, al_id=116673
+        )
+
+        self.assertEqual(
+            sorted(ep["episodeNumber"] for ep in ep_list), [1, 2, 3]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,180 @@
+"""
+Unit tests for AniList/AniDB episode matching.
+
+Regression coverage for the special/OVA/movie mis-mapping bug: the Kometa
+Anime-IDs file keys each entry by its AniDB ID (the ID lives in the dict key,
+not the value), so get_mappings_from_anime_mappings must fold the key into the
+mapping as ``anidb_id``. Without it, get_ep_list never consults the AniDB
+episode mapping-list and the naive offset slice picks the wrong special episode
+(e.g. S00E01 instead of S00E31 for Attack on Titan ~Chronicle~).
+
+Run with: python -m pytest tests/test_matching.py -v
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+from xml.etree import ElementTree
+
+from seadexarr.modules.seadex_arr import SeaDexArr
+from seadexarr.modules.seadex_sonarr import SeaDexSonarr
+
+
+# AniDB anime-list fragment for Shingeki no Kyojin: Chronicle (anidbid 15582).
+# mapping ;1-31; means TVDB S00E31 maps to the single AniList episode.
+_ANIDB_XML = """
+<anime-list>
+  <anime anidbid="15582" tvdbid="267440" defaulttvdbseason="0">
+    <name>Shingeki no Kyojin: Chronicle</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-31;</mapping>
+    </mapping-list>
+  </anime>
+</anime-list>
+"""
+
+# The real Kometa Anime-IDs shape: AniDB ID is the KEY, never inside the value.
+_ANIME_IDS = {
+    "15582": {
+        "tvdb_id": 267440,
+        "tvdb_season": 0,
+        "tvdb_epoffset": 0,
+        "imdb_id": "tt12415546",
+        "mal_id": 42091,
+        "anilist_id": 119113,
+    },
+}
+
+# Sonarr episode payload: the recap special sits at S00E31 (has the Meakes
+# file); S00E01 is a different, file-less recap; plus a normal S01 episode.
+_SONARR_EPISODES = [
+    {"seasonNumber": 0, "episodeNumber": 1, "episodeFileId": 0, "monitored": True},
+    {
+        "seasonNumber": 0,
+        "episodeNumber": 31,
+        "episodeFileId": 37615,
+        "monitored": True,
+        "episodeFile": {"releaseGroup": "Meakes", "size": 34_860_000_000},
+    },
+    {
+        "seasonNumber": 1,
+        "episodeNumber": 1,
+        "episodeFileId": 5,
+        "monitored": True,
+        "episodeFile": {"releaseGroup": "SomeoneElse", "size": 1_000_000_000},
+    },
+]
+
+
+def _make_arr() -> SeaDexArr:
+    arr = SeaDexArr.__new__(SeaDexArr)
+    arr.anime_mappings = _ANIME_IDS
+    arr.anibridge_mappings = {}
+    arr.logger = MagicMock()
+    return arr
+
+
+def _make_sonarr(anidb_mappings) -> SeaDexSonarr:
+    s = SeaDexSonarr.__new__(SeaDexSonarr)
+    s.sonarr_url = "http://sonarr.test"
+    s.sonarr_api_key = "key"
+    s.anidb_mappings = anidb_mappings
+    s.al_cache = {}
+    s.logger = MagicMock()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# anidb_id wiring
+# ---------------------------------------------------------------------------
+
+class TestAnimeMappingAnidbId(unittest.TestCase):
+
+    def test_anidb_id_folded_from_key(self):
+        arr = _make_arr()
+        mappings = arr.get_mappings_from_anime_mappings(tvdb_id=267440)
+
+        self.assertIn(119113, mappings)
+        self.assertEqual(mappings[119113]["anidb_id"], "15582")
+        # Original value fields preserved
+        self.assertEqual(mappings[119113]["tvdb_season"], 0)
+        self.assertEqual(mappings[119113]["anilist_id"], 119113)
+
+    def test_existing_anidb_id_in_value_not_clobbered(self):
+        arr = _make_arr()
+        arr.anime_mappings = {
+            "15582": {**_ANIME_IDS["15582"], "anidb_id": "explicit"},
+        }
+        mappings = arr.get_mappings_from_anime_mappings(tvdb_id=267440)
+        self.assertEqual(mappings[119113]["anidb_id"], "explicit")
+
+    def test_anidb_id_present_via_imdb_lookup(self):
+        arr = _make_arr()
+        mappings = arr.get_mappings_from_anime_mappings(imdb_id="tt12415546")
+        self.assertEqual(mappings[119113]["anidb_id"], "15582")
+
+
+# ---------------------------------------------------------------------------
+# get_ep_list special-episode selection
+# ---------------------------------------------------------------------------
+
+class TestGetEpListSpecial(unittest.TestCase):
+
+    def _run_get_ep_list(self, mapping, anidb_mappings):
+        s = _make_sonarr(anidb_mappings)
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = list(_SONARR_EPISODES)
+
+        with patch(
+            "seadexarr.modules.seadex_sonarr.requests.get", return_value=resp
+        ), patch(
+            "seadexarr.modules.seadex_sonarr.get_anilist_format",
+            return_value=("MOVIE", {}),
+        ), patch(
+            "seadexarr.modules.seadex_sonarr.get_anilist_n_eps",
+            return_value=(1, {}),
+        ):
+            return s.get_ep_list(
+                sonarr_series_id=63,
+                al_id=119113,
+                mapping=mapping,
+            )
+
+    def test_anidb_mapping_selects_correct_special(self):
+        """With anidb_id wired, the AniDB mapping-list picks S00E31 (Meakes)."""
+        root = ElementTree.fromstring(_ANIDB_XML)
+        mapping = {
+            "tvdb_id": 267440,
+            "tvdb_season": 0,
+            "tvdb_epoffset": 0,
+            "anilist_id": 119113,
+            "anidb_id": "15582",
+        }
+
+        ep_list = self._run_get_ep_list(mapping, root)
+
+        self.assertEqual(len(ep_list), 1)
+        self.assertEqual(ep_list[0]["seasonNumber"], 0)
+        self.assertEqual(ep_list[0]["episodeNumber"], 31)
+        self.assertEqual(ep_list[0]["episodeFile"]["releaseGroup"], "Meakes")
+
+    def test_missing_anidb_id_regresses_to_wrong_episode(self):
+        """Demonstrates the original bug: no anidb_id => offset slice picks E01."""
+        mapping = {
+            "tvdb_id": 267440,
+            "tvdb_season": 0,
+            "tvdb_epoffset": 0,
+            "anilist_id": 119113,
+            # anidb_id intentionally absent
+        }
+
+        ep_list = self._run_get_ep_list(mapping, None)
+
+        self.assertEqual(len(ep_list), 1)
+        self.assertEqual(ep_list[0]["episodeNumber"], 1)
+        self.assertEqual(ep_list[0]["episodeFileId"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unraid/seadexarr-audit.xml
+++ b/unraid/seadexarr-audit.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>SeaDexArr-Audit</Name>
+  <Repository>ghcr.io/gregoryn22/seadexarr:main</Repository>
+  <Registry>https://github.com/gregoryn22/seadexarr/pkgs/container/seadexarr</Registry>
+  <Network>bridge</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/gregoryn22/seadexarr/issues</Support>
+  <Project>https://github.com/gregoryn22/seadexarr</Project>
+  <Overview>SeaDexArr audit mode - scans your Sonarr library against SeaDex, applies Sonarr tags (seadex / partial-seadex / seadex-upgrade-available / seadex-too-large), and sends Discord notifications when recommendations change. Never downloads, grabs, or replaces files. Before starting: mount /config, run once with AUDIT_ARGS=--dry-run to generate config.yml, edit it with your Sonarr URL/API key/Discord webhook, then switch AUDIT_ARGS to --apply-tags.</Overview>
+  <Category>MediaApp:Other</Category>
+  <WebUI/>
+  <TemplateURL>https://raw.githubusercontent.com/gregoryn22/seadexarr/main/unraid/seadexarr-audit.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/bbtufty/seadexarr/main/docs/_static/seadexarr.png</Icon>
+  <ExtraParams>--restart=unless-stopped</ExtraParams>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled/>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+
+  <Config Name="Config Directory" Target="/config" Default="/mnt/user/appdata/seadexarr" Mode="rw" Description="Persistent config directory. Holds config.yml, cache.json, and audit_state.json." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/seadexarr</Config>
+
+  <Config Name="Run Mode" Target="RUN_MODE" Default="audit" Description="audit = run audit on a repeating schedule (recommended). audit-once = run once and exit. sync = original grab/sync mode." Type="Variable" Display="always" Required="true" Mask="false">audit</Config>
+
+  <Config Name="Audit Schedule (hours)" Target="AUDIT_SCHEDULE_TIME" Default="6" Description="Hours between audit runs. Only used when RUN_MODE=audit." Type="Variable" Display="always" Required="true" Mask="false">6</Config>
+
+  <Config Name="Audit Flags" Target="AUDIT_ARGS" Default="--apply-tags" Description="Flags passed to seadexarr audit. --apply-tags writes Sonarr tags (no downloads). --dry-run previews without any mutations. --notify-only sends Discord without changing tags." Type="Variable" Display="always" Required="true" Mask="false">--apply-tags</Config>
+
+  <Config Name="Sync Schedule (hours)" Target="SCHEDULE_TIME" Default="6" Description="Hours between runs when RUN_MODE=sync (original grab mode). Ignored in audit mode." Type="Variable" Display="advanced" Required="false" Mask="false">6</Config>
+
+  <Config Name="Log Level" Target="LOG_LEVEL" Default="INFO" Description="Log verbosity: DEBUG, INFO, WARNING, CRITICAL." Type="Variable" Display="advanced" Required="false" Mask="false">INFO</Config>
+
+</Container>

--- a/unraid/seadexarr-audit.xml
+++ b/unraid/seadexarr-audit.xml
@@ -13,7 +13,7 @@
   <WebUI/>
   <TemplateURL>https://raw.githubusercontent.com/gregoryn22/seadexarr/main/unraid/seadexarr-audit.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/bbtufty/seadexarr/main/docs/_static/seadexarr.png</Icon>
-  <ExtraParams>--restart=unless-stopped</ExtraParams>
+  <ExtraParams>--restart=unless-stopped --stop-timeout=120</ExtraParams>
   <PostArgs/>
   <CPUset/>
   <DateInstalled/>
@@ -21,7 +21,7 @@
   <DonateLink/>
   <Requires/>
 
-  <Config Name="Config Directory" Target="/config" Default="/mnt/user/appdata/seadexarr" Mode="rw" Description="Persistent config directory. Holds config.yml, cache.json, and audit_state.json." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/seadexarr</Config>
+  <Config Name="Config Directory" Target="/config" Default="/mnt/user/appdata/seadexarr" Mode="rw" Description="Persistent config directory. Holds config.yml, cache.json, and audit_state.db." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/seadexarr</Config>
 
   <Config Name="Run Mode" Target="RUN_MODE" Default="audit" Description="audit = run audit on a repeating schedule (recommended). audit-once = run once and exit. sync = original grab/sync mode." Type="Variable" Display="always" Required="true" Mask="false">audit</Config>
 


### PR DESCRIPTION
## What & why

Two audit fixes diagnosed from production logs.

### 1. Crash on `+`-grouped AniDB mappings
AniDB anime-list mapping text can map a single AniDB episode onto several TVDB
episodes using `+` (e.g. `;1-1+2+3;` for Burn the Witch). `get_ep_list` assumed
each mapping was two plain ints and blew up:

```
ValueError: invalid literal for int() with base 10: '1+2+3'
```

That aborted the entire series audit. Now `+`-joined TVDB groups are expanded so
each TVDB episode points back at its AniDB episode.

### 2. Misleading `→ tagging` log when an owned alt is acceptable
With `alt_is_acceptable: true`, a series whose library already holds a SeaDex
alt is correctly **not** flagged for upgrade. But `filter_by_release_group` still
printed `Have: [Alt] | SeaDex: [Best] → tagging` at INFO, because it ran before
the alt rescue and had no knowledge of it — so the log contradicted the final
(correct) decision.

Fix: compute `acceptable_alt_owned` once in `_audit_al_id` via a new
`_library_has_seadex_rg` helper (same tracker / public_only / ignore-tag filters
as `get_seadex_dict`), thread it into `filter_seadex_downloads` →
`filter_by_release_group`, and demote those per-release lines to DEBUG with
`→ have acceptable alt ✓` when set. The existing rescue reuses the same flag
instead of recomputing the candidate set.

## Reviewer notes
- Download / non-audit paths pass nothing → param defaults to `False` → behavior unchanged.
- No behavior change to the final tag decision for case 2 — it was already correct; only the log was wrong.
- Investigated a suspected cour-mapping bug (Blue Exorcist CRUCiBLE vs hchcsen): **not a bug**. Kometa maps the cours to distinct TVDB seasons (S4 vs S5, offset 0); the flag is legitimate (library S5 files are CRUCiBLE, which isn't a SeaDex release for that entry). No code change.

## Tests
`python -m pytest tests/` → 53 passed. Added:
- regression for `+`-grouped mapping (`test_matching.py`)
- `acceptable_alt_owned` kwarg flow + log level/wording (`test_audit.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
